### PR TITLE
Pay attention to role name changes + RankContainer/RankCommand changes

### DIFF
--- a/src/main/kotlin/me/aberrantfox/aegeus/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/aegeus/MainApp.kt
@@ -36,7 +36,8 @@ fun main(args: Array<String>) {
             VoiceChannelListener(logChannel),
             NewChannelListener(mutedRole),
             DuplicateMessageListener(config, logChannel, tracker),
-            BanReasonReminderListener(config))
+            BanReasonReminderListener(config),
+            RoleListener(config))
 
     jda.presence.setPresence(OnlineStatus.ONLINE, Game.of("${config.prefix}help"))
     jda.guilds.forEach { setupMutedRole(it, config.mutedRole) }

--- a/src/main/kotlin/me/aberrantfox/aegeus/commandframework/commands/RankCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/aegeus/commandframework/commands/RankCommands.kt
@@ -27,15 +27,16 @@ object RankContainer {
         }
     }
 
-    fun canUse(role: String) = this.config.acceptableRanks.contains(role)
+
+    fun canUse(role: String) = this.config.acceptableRanks.contains(role.toLowerCase())
 
     fun add(role: String) {
-        this.config.acceptableRanks.add(role)
+        this.config.acceptableRanks.add(role.toLowerCase())
         this.save()
     }
 
     fun remove(role: String) {
-        this.config.acceptableRanks.remove(role)
+        this.config.acceptableRanks.remove(role.toLowerCase())
         this.save()
     }
 
@@ -75,6 +76,11 @@ fun rankCommands() = commands {
                 return@execute
             }
 
+            if (RankContainer.canUse(role)) {
+                it.respond("A role with that name is already grantable.")
+                return@execute
+            }
+
             RankContainer.add(role)
             it.respond("The role: $role has been added to the role whitelist, and can now be assigned via the grant command.")
         }
@@ -85,8 +91,8 @@ fun rankCommands() = commands {
         execute {
             val role = it.args[0] as String
 
-            if (!(it.jda.isRole(role))) {
-                it.respond("Error, that is not a role, or there are more than one roles by that name.")
+            if (!(RankContainer.canUse(role))) {
+                it.respond("Error: a role with that name hasn't been made grantable or doesn't exist")
                 return@execute
             }
 

--- a/src/main/kotlin/me/aberrantfox/aegeus/listeners/RoleListener.kt
+++ b/src/main/kotlin/me/aberrantfox/aegeus/listeners/RoleListener.kt
@@ -9,5 +9,11 @@ class RoleListener(val configuration: Configuration) : ListenerAdapter() {
     override fun onRoleUpdateName(event: RoleUpdateNameEvent) {
         val oldName = event.oldName
         val newName = event.role.name
+
+        // Update grantable role
+        if(RankContainer.canUse(oldName)) {
+            RankContainer.remove(oldName)
+            RankContainer.add(newName)
+        }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/aegeus/listeners/RoleListener.kt
+++ b/src/main/kotlin/me/aberrantfox/aegeus/listeners/RoleListener.kt
@@ -1,0 +1,13 @@
+package me.aberrantfox.aegeus.listeners
+
+import net.dv8tion.jda.core.hooks.ListenerAdapter
+import net.dv8tion.jda.core.events.role.update.RoleUpdateNameEvent
+import me.aberrantfox.aegeus.services.Configuration
+import me.aberrantfox.aegeus.commandframework.commands.RankContainer
+
+class RoleListener(val configuration: Configuration) : ListenerAdapter() {
+    override fun onRoleUpdateName(event: RoleUpdateNameEvent) {
+        val oldName = event.oldName
+        val newName = event.role.name
+    }
+}

--- a/src/main/kotlin/me/aberrantfox/aegeus/listeners/RoleListener.kt
+++ b/src/main/kotlin/me/aberrantfox/aegeus/listeners/RoleListener.kt
@@ -11,7 +11,7 @@ class RoleListener(val configuration: Configuration) : ListenerAdapter() {
         val newName = event.role.name
 
         // Update grantable role
-        if(RankContainer.canUse(oldName)) {
+        if (RankContainer.canUse(oldName)) {
             RankContainer.remove(oldName)
             RankContainer.add(newName)
         }


### PR DESCRIPTION
## RoleListener

- Listen for role name changes and:
  - Update the grantable roles if any of the names have changed.
- Couldn't see any other places needing role name updates currently. I did see the possibility of updating the roles on their name change in PermissionStructure.kt/Configuration.kt, but iirc you are going to improve/change the configuration and permission structure, so I left it.

## RankContainer storing in lowercase

- Consistency.
- Prevents duplicates being added like:

![rwbop8s](https://user-images.githubusercontent.com/12241208/34467880-a2a43034-eef4-11e7-9de8-fced75efb708.png)
(There's only one muted role on that server)


## Rank command checks

#### makerolegrantable
- Check to see if there already exists a grantable role with the name you are trying to add 

#### makeroleungrantable
- Instead of checking if a role exists in general on the whole server, just check to see if it's grantable.
- Before, if you removed a role or changed the name, you wouldn't be able to make it ungrantable since it no longer "existed", but this fixes that, along with the name change listener.
  
  