### PR TITLE
Added bird command using birdsare.cool API

### DIFF
--- a/src/main/kotlin/me/aberrantfox/aegeus/commandframework/commands/FunCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/aegeus/commandframework/commands/FunCommands.kt
@@ -18,6 +18,13 @@ fun funCommands() =
                 it.respond(json.getString("file"))
             }
         }
+        
+        command("bird") {
+            execute {
+                val json = kget("https://birdsare.cool/bird.json?exclude=webm,mp4").jsonObject
+                it.respond(json.getString("url"))
+            }
+        }
 
         command("ball") {
             expect(ArgumentType.Sentence)


### PR DESCRIPTION
A carbon copy of the random.cat API command but made for https://birdsare.cool/
The API call excludes webm and mp4 files to avoid non-embedded messages in discord.

The website has a repository if you need to take a look at it:
https://github.com/vallode/birdsarecool
  