### PR TITLE
Change Infraction DMs to Embeds

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -48,7 +48,7 @@ fun strikeCommands() =
 
                 it.author.openPrivateChannel().queue {
                     it.sendMessage("User ${target.idToUser(it.jda).asMention} has been infracted with weight: $strikeQuantity," +
-                        " with reason $reason.").queue()
+                        " with reason:\n\n$reason.").queue()
                 }
 
                 var totalStrikes = getMaxStrikes(target)
@@ -132,7 +132,7 @@ private fun handleInfraction(event: CommandEvent) {
 
     event.author.openPrivateChannel().queue {
         it.sendMessage("User ${target.idToUser(event.jda).asMention} has been infracted with weight: $strikeQuantity," +
-            " with reason $reason.").queue()
+            " with reason:\n\n$reason.").queue()
     }
 
     var totalStrikes = getMaxStrikes(target)
@@ -164,7 +164,7 @@ private fun strike(event: CommandEvent) {
 
     event.author.openPrivateChannel().queue {
         it.sendMessage("User ${target.idToUser(event.jda).asMention} has been infracted with weight: $strikeQuantity," +
-            " with reason:\n\n$reason.").queue()
+            " with reason:\n\n$reason").queue()
     }
 
     var totalStrikes = getMaxStrikes(target)

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -164,7 +164,7 @@ private fun strike(event: CommandEvent) {
 
     event.author.openPrivateChannel().queue {
         it.sendMessage("User ${target.idToUser(event.jda).asMention} has been infracted with weight: $strikeQuantity," +
-            " with reason $reason.").queue()
+            " with reason:\n\n$reason.").queue()
     }
 
     var totalStrikes = getMaxStrikes(target)

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -211,7 +211,8 @@ private fun buildInfractionEmbed(userMention: String, reason: String, strikeQuan
                                  strikeCeil: Int, punishmentAction: String) =
         embed {
             title("Infraction")
-            description("$userMention, you have been infracted.\nInfractions are formal warnings from staff members on TPH.")
+            description("$userMention, you have been infracted.\nInfractions are formal warnings from staff members on TPH.\n" +
+                        "If you think your infraction is undoubtedly unjustified, please **do not** post about it in a public channel but take it up with an administrator.")
 
             ifield {
                 name = "Strike Quantity"

--- a/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
@@ -6,7 +6,9 @@ import net.dv8tion.jda.core.entities.Guild
 import net.dv8tion.jda.core.entities.MessageEmbed
 import net.dv8tion.jda.core.entities.Role
 import net.dv8tion.jda.core.entities.User
+import java.awt.Color
 import java.util.*
+
 
 data class MuteRecord(val unmuteTime: Long, val reason: String, val moderator: String, val user: String, val guildId: String)
 
@@ -62,13 +64,11 @@ fun muteMember(guild: Guild, user: User, time: Long, reason: String, config: Con
 
         config.security.mutedMembers.add(record)
         unmute(guild, user, config, time, record)
-
     }
 
     moderator.openPrivateChannel().queue {
-        it.sendMessage("User ${user.asMention} has been muted for $timeString.").queue()
+        it.sendMessage("User ${user.asMention} has been muted for $timeString, with reason:\n\n$reason").queue()
     }
-
 }
 
 fun unmute(guild: Guild, user: User, config: Configuration, time: Long, muteRecord: MuteRecord) {

--- a/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
@@ -1,5 +1,6 @@
 package me.aberrantfox.hotbot.extensions
 
+import me.aberrantfox.hotbot.dsls.embed.embed
 import me.aberrantfox.hotbot.services.Configuration
 import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.entities.Guild
@@ -48,7 +49,7 @@ fun permMuteMember(guild: Guild, user: User, reason: String, config: Configurati
     guild.controller.addRolesToMember(guild.getMemberById(user.id), guild.getRolesByName(config.security.mutedRole, true)).queue()
 
     user.openPrivateChannel().queue {
-        val muteEmbed = buildMuteEmbed("Indefinite", reason)
+        val muteEmbed = buildMuteEmbed(user.asMention, "Indefinite", reason)
 
         it.sendMessage(muteEmbed).queue()
     }
@@ -62,7 +63,7 @@ fun muteMember(guild: Guild, user: User, time: Long, reason: String, config: Con
         val timeToUnmute = futureTime(time)
         val record = MuteRecord(timeToUnmute, reason, moderator.id, user.id, guild.id)
 
-        val muteEmbed = buildMuteEmbed(timeString, reason)
+        val muteEmbed = buildMuteEmbed(user.asMention, timeString, reason)
         it.sendMessage(muteEmbed).queue()
 
         config.security.mutedMembers.add(record)
@@ -74,10 +75,10 @@ fun muteMember(guild: Guild, user: User, time: Long, reason: String, config: Con
     }
 }
 
-private fun buildMuteEmbed(timeString: String, reason: String) =
+private fun buildMuteEmbed(userMention: String, timeString: String, reason: String) =
         embed {
             title("Mute")
-            description("You have been muted for:")
+            description("$userMention, you have been muted.\nA muted user cannot speak, post in channels, or react to messages.")
 
             field {
                 name = "Length"

--- a/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
@@ -48,7 +48,9 @@ fun permMuteMember(guild: Guild, user: User, reason: String, config: Configurati
     guild.controller.addRolesToMember(guild.getMemberById(user.id), guild.getRolesByName(config.security.mutedRole, true)).queue()
 
     user.openPrivateChannel().queue {
-        it.sendMessage("You have been muted indefinitely, for reason: $reason").queue()
+        val muteEmbed = buildMuteEmbed("Indefinite", reason)
+
+        it.sendMessage(muteEmbed).queue()
     }
 }
 
@@ -60,7 +62,8 @@ fun muteMember(guild: Guild, user: User, time: Long, reason: String, config: Con
         val timeToUnmute = futureTime(time)
         val record = MuteRecord(timeToUnmute, reason, moderator.id, user.id, guild.id)
 
-        it.sendMessage("You have been muted for $timeString, reason: $reason").queue()
+        val muteEmbed = buildMuteEmbed(timeString, reason)
+        it.sendMessage(muteEmbed).queue()
 
         config.security.mutedMembers.add(record)
         unmute(guild, user, config, time, record)
@@ -70,6 +73,27 @@ fun muteMember(guild: Guild, user: User, time: Long, reason: String, config: Con
         it.sendMessage("User ${user.asMention} has been muted for $timeString, with reason:\n\n$reason").queue()
     }
 }
+
+private fun buildMuteEmbed(timeString: String, reason: String) =
+        embed {
+            title("Mute")
+            description("You have been muted for:")
+
+            field {
+                name = "Length"
+                value = timeString
+                inline = false
+            }
+
+            field {
+                name = "__Reason__"
+                value = reason
+                inline = false
+            }
+
+
+            setColor(Color.RED)
+        }
 
 fun unmute(guild: Guild, user: User, config: Configuration, time: Long, muteRecord: MuteRecord) {
     if (time <= 0) {


### PR DESCRIPTION
# Summary
Changes the direct messages sent by HotBot to 'infracted' users to embeds, making it clearer and explicit in general, and obvious what the reason is. There are also some newlines added to the messages sent to staff members to separate the reason, making them look a bit nicer.
#### Closes #16 

# Changes

## Staff Infraction DMs
![](https://i.imgur.com/nEFCTXt.png)
![](https://i.imgur.com/MHBFY5X.png)

## Infraction + Mute DM Embeds
### Strike
![](https://i.imgur.com/gC28DvZ.png)
### Mute
![](https://i.imgur.com/WsX6kJ2.png)
### Strike Leading to Mute
![](https://i.imgur.com/v1Ig7xj.png)
### Indefinite Mute (Spam)
![](https://i.imgur.com/lzgsIAD.png)