### PR TITLE
Fix: avatarUrl bug, and cleanse not taking arguments

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
@@ -71,7 +71,7 @@ fun embedCommands() =
 
         command("setselfauthor") {
             execute {
-                EHolder.embed.setAuthor(it.author.fullName(), null, it.author.avatarUrl)
+                EHolder.embed.setAuthor(it.author.fullName(), null, it.author.effectiveAvatarUrl)
             }
         }
 
@@ -79,7 +79,7 @@ fun embedCommands() =
             expect(ArgumentType.UserID)
             execute {
                 val target = (it.args[0] as String).idToUser(it.jda)
-                EHolder.embed.setAuthor(target.fullName(), null, target.avatarUrl)
+                EHolder.embed.setAuthor(target.fullName(), null, target.effectiveAvatarUrl)
             }
         }
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/ProfilesCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/ProfilesCommands.kt
@@ -21,7 +21,7 @@ fun profileCommands() = commands {
         execute {
             val profileText = it.args[0] as String
 
-            val response = Profiles.pool.addRecord(it.author.id, it.author.avatarUrl, profileText)
+            val response = Profiles.pool.addRecord(it.author.id, it.author.effectiveAvatarUrl, profileText)
 
             when (response) {
                 AddResponse.Accepted -> it.respond("Your profile has been added to the review pool. An administrator will review it shortly.")

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -99,6 +99,7 @@ fun strikeCommands() =
         }
 
         command("cleanse") {
+            expect(ArgumentType.UserID)
             execute {
                 val userId = it.args[0] as String
                 val amount = removeAllInfractions(userId)

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -66,7 +66,7 @@ fun strikeCommands() =
                 val builder = EmbedBuilder()
                     .setTitle("${target.idToName(it.jda)}'s Record")
                     .setColor(Color.MAGENTA)
-                    .setThumbnail(target.idToUser(it.jda).avatarUrl)
+                    .setThumbnail(target.idToUser(it.jda).effectiveAvatarUrl)
 
                 records.forEach { record ->
                     builder.addField("Strike ID: ${record.id}",

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/SuggestionCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/SuggestionCommands.kt
@@ -34,7 +34,7 @@ fun suggestionCommands() = commands {
             val author = it.author.id
             val message = it.args[0] as String
 
-            val response = Suggestions.pool.addRecord(author, it.author.avatarUrl, message)
+            val response = Suggestions.pool.addRecord(author, it.author.effectiveAvatarUrl, message)
 
             when (response) {
                 AddResponse.PoolFull -> it.respond("You have enough suggestions in the pool for now...")

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/MemberListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/MemberListener.kt
@@ -17,7 +17,7 @@ class MemberListener(val configuration: Configuration, val logger: BotLogger) : 
     override fun onGuildMemberJoin(event: GuildMemberJoinEvent) {
         val target = event.guild.textChannels.findLast { it.id == configuration.messageChannels.welcomeChannel }
         val response = MessageService.getMessage(MessageType.Join).replace("%name%", event.user.asMention)
-        val userImage = event.user.avatarUrl ?: "http://i.imgur.com/HYkhEFO.jpg"
+        val userImage = event.user.effectiveAvatarUrl
 
         target?.sendMessage(buildJoinMessage(response, userImage))?.queue {
             it.addReaction("\uD83D\uDC4B").queue()


### PR DESCRIPTION
## Avatar URL Bug
`avatarUrl`s of users were previously possible to be null, causing those people to not be able to use commands like `suggest` and their avatar not showing up on `history`.

`avatarUrl` -> `effectiveAvatarUrl`

Closes #36 

## Cleanse Command Arguments
The cleanse command wasn't expecting any arguments but should have been taking a user id.

-> `expect(ArgumentType.UserID)`

![](https://i.imgur.com/2E1S5Eo.png)
fixed:

![](https://i.imgur.com/XG7zHSp.png)
