### PR TITLE
Embed commands: copyembed, editfield + fixes

### DIFF
--- a/help.json
+++ b/help.json
@@ -312,8 +312,8 @@
     {
       "name": "copyembed",
       "category": "embed",
-      "description": "Copies the embed from the message with the given id into the embed builder. You have to be in the same channel as the embed message to copy it.",
-      "structure": "{messageId}",
+      "description": "Copies the embed from the message with the given id into the embed builder. The channelId from which to get the embed is optional and will default to the one you invoked the command in.",
+      "structure": "{messageId} [channelId]",
       "example": "404551348739112961"
     },
     {

--- a/help.json
+++ b/help.json
@@ -310,6 +310,20 @@
       "example": ""
     },
     {
+      "name": "copyembed",
+      "category": "embed",
+      "description": "Copies the embed from the message with the given id into the embed builder. You have to be in the same channel as the embed message to copy it.",
+      "structure": "{messageId}",
+      "example": "404551348739112961"
+    },
+    {
+      "name": "editfield",
+      "category": "embed",
+      "description": "Edits a field in the current embed being worked on. The passed index should be from 0 to fields.size - 1. Properties: name, text (or value), inline.",
+      "structure": "{fieldIndex} {property} {newValue}",
+      "example": "0 name New title of field"
+    },
+    {
       "name": "setTitle",
       "category": "embed",
       "description": "Set the title of the embed in memory",

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
@@ -6,6 +6,7 @@ import me.aberrantfox.hotbot.extensions.fullName
 import me.aberrantfox.hotbot.extensions.idToUser
 import me.aberrantfox.hotbot.dsls.command.commands
 import me.aberrantfox.hotbot.extensions.isBooleanValue
+import me.aberrantfox.hotbot.extensions.toBooleanValue
 import net.dv8tion.jda.core.EmbedBuilder
 import net.dv8tion.jda.core.entities.MessageEmbed
 import java.awt.Color
@@ -55,6 +56,46 @@ fun embedCommands() =
                     { error -> // Failure
                         it.respond("Message retrieval failed.")
                     })
+            }
+        }
+
+        command("editfield") {
+            expect(ArgumentType.Integer, ArgumentType.Word, ArgumentType.Sentence)
+            execute {
+                val fields = EHolder.embed.fields
+
+                val fieldIndex = it.args[0] as Int
+                if (fieldIndex < 0 || fieldIndex > fields.size - 1) {
+                    it.respond("Not a valid field index")
+                    return@execute
+                }
+
+                val property = (it.args[1] as String).toLowerCase()
+                val newValue = it.args[2] as String
+
+                val field = fields[fieldIndex]
+                var name = field.name
+                var text = field.value
+                var inline = field.isInline
+
+                when(property) {
+                    "name" -> name = newValue
+                    "text", "value" -> text = newValue
+                    "inline" -> {
+                        if(!newValue.isBooleanValue()) {
+                            it.respond("You haven't supplied a boolean value")
+                            return@execute
+                        }
+
+                        inline = newValue.toBooleanValue()
+                    }
+                    else -> {
+                        it.respond("That isn't a valid property")
+                        return@execute
+                    }
+                }
+
+                fields[fieldIndex] = MessageEmbed.Field(name, text, inline)
             }
         }
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
@@ -36,6 +36,28 @@ fun embedCommands() =
             }
         }
 
+        command("copyembed") {
+            expect(ArgumentType.Word)
+            execute {
+                val messageId = it.args[0] as String
+
+                it.channel.getMessageById(messageId).queue(
+                    { msg -> // Success
+                        val embed = msg?.embeds?.firstOrNull()
+
+                        if (embed == null) {
+                            it.respond("Message doesn't contain any embeds")
+                            return@queue
+                        }
+
+                        EHolder.embed = EmbedBuilder(embed)
+                    },
+                    { error -> // Failure
+                        it.respond("Message retrieval failed.")
+                    })
+            }
+        }
+
         command("settitle") {
             expect(ArgumentType.Sentence)
             execute {

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
@@ -5,7 +5,9 @@ import me.aberrantfox.hotbot.commandframework.CommandSet
 import me.aberrantfox.hotbot.extensions.fullName
 import me.aberrantfox.hotbot.extensions.idToUser
 import me.aberrantfox.hotbot.dsls.command.commands
+import me.aberrantfox.hotbot.extensions.isBooleanValue
 import net.dv8tion.jda.core.EmbedBuilder
+import net.dv8tion.jda.core.entities.MessageEmbed
 import java.awt.Color
 import java.time.Instant
 
@@ -50,7 +52,11 @@ fun embedCommands() =
             }
         }
 
-        command("addtimestamp") { EHolder.embed.setTimestamp(Instant.now()) }
+        command("addtimestamp") {
+            execute {
+                EHolder.embed.setTimestamp(Instant.now())
+            }
+        }
 
         command("setcolour") {
             expect(ArgumentType.Double, ArgumentType.Double, ArgumentType.Double)
@@ -110,7 +116,9 @@ fun embedCommands() =
         }
 
         command("addfield") {
-            EHolder.embed.addField(FHolder.name, FHolder.text, false)
+            execute {
+                EHolder.embed.addField(FHolder.name, FHolder.text, false)
+            }
         }
 
         command("addIfield") {
@@ -120,11 +128,17 @@ fun embedCommands() =
         }
 
         command("clearFieldHolder") {
-            FHolder.name = ""
-            FHolder.text = ""
+            execute {
+                FHolder.name = ""
+                FHolder.text = ""
+            }
         }
 
-        command("clearfields") { EHolder.embed.clearFields() }
+        command("clearfields") {
+            execute {
+                EHolder.embed.clearFields()
+            }
+        }
 
         command("setfname") {
             expect(ArgumentType.Sentence)

--- a/src/main/kotlin/me/aberrantfox/hotbot/extensions/NumberUtility.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/extensions/NumberUtility.kt
@@ -28,6 +28,14 @@ fun String.isInteger(): Boolean =
             false
         }
 
+fun String.isLong(): Boolean =
+        try {
+            this.toLong()
+            true
+        } catch (e: NumberFormatException) {
+            false
+        }
+
 fun String.isDouble(): Boolean =
         try {
             this.toDouble()


### PR DESCRIPTION
## Fixes
Some command contents were not wrapped in execute blocks, so they were only executed when the command was constructed; e.g.

![](https://i.imgur.com/9rUEOn4.png)

### Fixed:

![](https://i.imgur.com/DGMMrR5.png)
```
command("addtimestamp") { EHolder.embed.setTimestamp(Instant.now()) }
```
to
```
command("addtimestamp") {
    execute {
        EHolder.embed.setTimestamp(Instant.now())
    }
}
```

## Command: copyembed
Copies the embed from the message with the supplied message id into the embed builder, allowing you to not have to reconstruct the entire thing. You can also supply a channel id to specify a channel from which to search for the embed message.

Closes #41 

### Embed in same channel:

![](https://i.imgur.com/VG2oBEa.png)

### Embed from another channel:

![](https://i.imgur.com/pN0SC8J.png)

## Command: editfield
With the copyembed command, I think it would useful if you could actually edit the fields once you've got them copied into the builder, so I added it (compare edited embeds with original one above). You pass in the index (from 0) of the field, the property to edit, and the new value.

![](https://i.imgur.com/h6uhOMn.png)

![](https://i.imgur.com/QqerKPm.png)

![](https://i.imgur.com/wYWcJgW.png)