### PR TITLE
feat: channel resources

### DIFF
--- a/help.json
+++ b/help.json
@@ -12,7 +12,8 @@
     "profiles": "Commands relating to the profile queue for posting developer profiles or introductions",
     "security": "Commands for modifying security features and thresholds of the bot.",
     "invites": "Commands for dictating how the bot will handle invites",
-    "rank": "Commands for granting and removing ranks."
+    "rank": "Commands for granting and removing ranks.",
+    "resources": "Commands related to channel resources"
   },
   "commands": [
     {
@@ -679,6 +680,41 @@
       "description": "google a thing",
       "structure": "{search term}",
       "example": "Stackoverflow"
+    },
+    {
+      "name": "addresource",
+      "category": "resources",
+      "description": "Add a channel resource to the current channel.",
+      "structure": "{section}|{info text}",
+      "example": "Books|Some Book - https://some.book.url/"
+    },
+    {
+      "name": "listresources",
+      "category": "resources",
+      "description": "List current channel resources",
+      "structure": "",
+      "example": ""
+    },
+    {
+      "name": "listresourcesids",
+      "category": "resources",
+      "description": "List current channel resources (w/ ids shown, for removeresource)",
+      "structure": "",
+      "example": ""
+    },
+    {
+      "name": "removeresource",
+      "category": "resources",
+      "description": "Remove one or more of current channel resources",
+      "structure": "{resourceID}|{resourceID}|...",
+      "example": "123|456|789"
+    },
+    {
+      "name": "resetresources",
+      "category": "resources",
+      "description": "Remove all of current channel resources.",
+      "structure": "",
+      "example": ""
     }
   ]
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/ChannelResourcesCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/ChannelResourcesCommands.kt
@@ -1,0 +1,119 @@
+package me.aberrantfox.hotbot.commandframework.commands
+
+import me.aberrantfox.hotbot.commandframework.ArgumentType
+import me.aberrantfox.hotbot.commandframework.CommandSet
+import me.aberrantfox.hotbot.database.*
+import me.aberrantfox.hotbot.dsls.command.CommandEvent
+import me.aberrantfox.hotbot.dsls.command.commands
+import me.aberrantfox.hotbot.dsls.embed.embed
+import java.awt.Color
+import net.dv8tion.jda.core.entities.MessageChannel as Channel
+
+@CommandSet
+fun channelResourceCommands() = commands {
+    command("addresource") {
+        expect(ArgumentType.Sentence)
+        execute {
+            val input = it.args[0] as String
+            val split = input.split("|")
+
+            if (split.size != 2) {
+                it.respond("Must specify both section and info. example: `section|info`")
+                return@execute
+            }
+
+            val (section, info) = split
+
+            if (section.length < 3 || info.length < 3) {
+                it.respond("Minimum length for `section` and `info` is 3 characters.")
+                return@execute
+            }
+
+            saveChannelResource(it.channel.id, section, info)
+            it.respond("Added resource: `$info` to: `$section`")
+        }
+    }
+
+    command("listresources") {
+        execute {
+            handleListResources(it)
+        }
+    }
+
+    command("listresourcesids") {
+        execute {
+            handleListResources(it, true)
+        }
+    }
+
+    command("removeresource") {
+        expect(ArgumentType.Splitter)
+        execute {
+            val ids: List<Int>
+
+            try {
+                ids = (it.args[0] as List<*>).map { it.toString().toInt() }
+            } catch (e: NumberFormatException) {
+                it.respond("Invalid channel resource id(s) provided.")
+                return@execute
+            }
+
+            val invalidIds: List<String>
+            val foundIds = fetchChannelResourcesByIds(it.channel.id, ids)
+            if (ids.size != foundIds.size) {
+                invalidIds = ids.filter { !foundIds.contains(it) }.map { it.toString() }
+                val list = invalidIds.joinToString(", ")
+                it.respond("No such channel resource id(s): $list")
+                return@execute
+            }
+
+            removeChannelResources(it.channel.id, foundIds)
+            it.respond("Removed ${foundIds.size} resource entries.")
+        }
+    }
+
+    command("resetresources") {
+        execute {
+            val resourcesCount = fetchChannelResources(it.channel.id).size
+            val channelMention = "<#${it.channel.id}>"
+
+            if (resourcesCount == 0) {
+                it.respond("Channel $channelMention has no resources.")
+                return@execute
+            }
+
+            removeAllChannelResources(it.channel.id)
+            it.respond("All channel resources removed ($resourcesCount).")
+        }
+    }
+}
+
+private fun handleListResources(ce: CommandEvent, showIds: Boolean = false) {
+    val resources = fetchChannelResources(ce.channel.id, showIds)
+
+    if (resources.isEmpty()) {
+        ce.respond("No resources found for <#${ce.channel.id}>.")
+        return
+    }
+
+    ce.respond(buildResourcesEmbed(ce.channel, resources))
+}
+
+private fun buildResourcesEmbed(channel: Channel, resources: Map<String, ResourceSection>) =
+    embed {
+        setColor(Color.decode("#177BBC"))
+        title("${channel.name.toUpperCase()} RESOURCES")
+        description("Current channel resources:\n\n")
+
+        resources.forEach { _, rs ->
+            val sb = StringBuilder()
+
+            rs.items.forEach { info -> sb.append("$info\n") }
+
+            field {
+                name = rs.section
+                value = sb.toString()
+                inline = false
+            }
+        }
+    }

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/ChannelResourcesTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/ChannelResourcesTransactions.kt
@@ -1,0 +1,71 @@
+package me.aberrantfox.hotbot.database
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+
+data class ResourceSection(val section: String, val items: MutableList<String>)
+
+fun saveChannelResource(channel: String, section: String, info: String) =
+        transaction {
+            ChannelResources.insert {
+                it[ChannelResources.channel] = channel
+                it[ChannelResources.section] = section
+                it[ChannelResources.info] = info
+            }
+        }
+
+fun removeChannelResources(channel: String, ids: List<Int>) =
+        transaction {
+            ChannelResources.deleteWhere {
+                Op.build {
+                    (ChannelResources.channel eq channel) and
+                    (ChannelResources.id inList ids)
+                }
+            }
+        }
+
+fun removeAllChannelResources(channel: String) =
+        transaction {
+            ChannelResources.deleteWhere {
+                Op.build { ChannelResources.channel eq channel }
+            }
+        }
+
+fun fetchChannelResources(channel: String, showIds: Boolean = false) =
+        transaction {
+            val sections: MutableMap<String, ResourceSection> = mutableMapOf()
+
+            ChannelResources.select {
+                Op.build { ChannelResources.channel eq channel }
+            }.forEach {
+                val name = it[ChannelResources.section]
+                val key = name.toUpperCase()
+                var info = it[ChannelResources.info]
+
+                if (showIds) {
+                    val id = it[ChannelResources.id]
+                    info = "[#$id]: $info"
+                }
+
+                if (!sections.containsKey(key)) {
+                    sections[key] = ResourceSection(name, mutableListOf(info))
+                } else {
+                    sections[key]?.items?.add(info)
+                }
+            }
+
+            sections
+        }
+
+fun fetchChannelResourcesByIds(channel: String, ids: List<Int>) =
+        transaction {
+            ChannelResources.select {
+                Op.build {
+                    (ChannelResources.id inList ids) and
+                    (ChannelResources.channel eq channel)
+                }
+            }
+            .map { it[ChannelResources.id] }
+            .toList()
+        }
+

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/SetupOperations.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/SetupOperations.kt
@@ -27,7 +27,7 @@ fun setupDatabaseSchema(config: Configuration) {
     )
 
     transaction {
-        SchemaUtils.create(Strikes, Suggestions, BanRecords, CommandPermissions)
+        SchemaUtils.create(Strikes, Suggestions, BanRecords, CommandPermissions, ChannelResources)
         logger.addLogger(StdOutSqlLogger)
     }
 }
@@ -60,4 +60,11 @@ object CommandPermissions : Table() {
     val id = integer("id").autoIncrement().primaryKey()
     val roleID = varchar("roleID", 18)
     val commandName = varchar("name", 256)
+}
+
+object ChannelResources : Table() {
+    val id = integer("id").autoIncrement().primaryKey()
+    val channel = varchar("channel", 18)
+    val section = varchar("section", 64)
+    val info = varchar("info", 255)
 }


### PR DESCRIPTION
channel resources feature w/ management commands (saves to database)

output example:

![2018-01-22_212809](https://user-images.githubusercontent.com/32434951/35258293-9a0bb5e6-ffbb-11e7-9df2-8d7c320c0c98.png)

help file updates provided, 5 commands:

- addresource
- listresources
- listresourcesids
- removeresource
- resetresources
