### PR TITLE
Add help documentation checker + Fix descriptions not showing

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
@@ -22,8 +22,16 @@ fun main(args: Array<String>) {
     val container = produceContainer()
     val config = loadConfig() ?: return
 
-
     saveConfig(config)
+
+    val helpErrors = HelpConf.getDocumentationErrors(container)
+    if (helpErrors.isNotEmpty()) {
+        println("The help documentation needs to be updated:")
+        helpErrors.forEach(::println)
+
+        return
+    }
+
     setupDatabaseSchema(config)
 
     val jda = JDABuilder(AccountType.BOT).setToken(config.serverInformation.token).buildBlocking()

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/HelpCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/HelpCommands.kt
@@ -52,6 +52,7 @@ fun helpCommands() =
 private fun buildCommandHelpMessage(config: Configuration, descriptor: CommandDescriptor) =
     embed {
         title("${descriptor.category} - ${descriptor.name}")
+        description(descriptor.description)
         setColor(Color.CYAN)
 
         field {

--- a/src/main/kotlin/me/aberrantfox/hotbot/services/HelpMessage.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/services/HelpMessage.kt
@@ -1,6 +1,7 @@
 package me.aberrantfox.hotbot.services
 
 import com.google.gson.Gson
+import me.aberrantfox.hotbot.dsls.command.CommandsContainer
 import java.io.File
 
 
@@ -55,4 +56,23 @@ object HelpConf {
                     .map { it.category }
                     .toSet()
                     .reduce { a, b ->  "$a, $b"}
+
+    fun getDocumentationErrors(container: CommandsContainer): List<String> {
+        val errors = ArrayList<String>()
+        val commandNames = container.commands.keys.map { it.toLowerCase() }
+
+        val docCommands = configuration.commands
+        val docCommandNames = docCommands.map { it.name.toLowerCase() }
+
+        val duplicates = docCommands.groupBy { it.name.toLowerCase() }.filter { it.value.size > 1 }
+        duplicates.forEach { errors.add("Duplicate command: ${it.key}") }
+
+        val undocumentedCommands = commandNames.filterNot { docCommandNames.contains(it) }
+        undocumentedCommands.forEach { errors.add("Undocumented command: $it") }
+
+        val unknownCommands = docCommandNames.filterNot { commandNames.contains(it) }
+        unknownCommands.forEach { errors.add("Unknown command: $it") }
+
+        return errors
+    }
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/services/HelpMessage.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/services/HelpMessage.kt
@@ -65,13 +65,19 @@ object HelpConf {
         val docCommandNames = docCommands.map { it.name.toLowerCase() }
 
         val duplicates = docCommands.groupBy { it.name.toLowerCase() }.filter { it.value.size > 1 }
-        duplicates.forEach { errors.add("Duplicate command: ${it.key}") }
+        if (duplicates.isNotEmpty()) {
+            errors.add("Duplicate Commands: ${duplicates.keys.joinToString(", ")}")
+        }
 
         val undocumentedCommands = commandNames.filterNot { docCommandNames.contains(it) }
-        undocumentedCommands.forEach { errors.add("Undocumented command: $it") }
+        if (undocumentedCommands.isNotEmpty()) {
+            errors.add("Undocumented Commands: ${undocumentedCommands.joinToString(", ")}")
+        }
 
         val unknownCommands = docCommandNames.filterNot { commandNames.contains(it) }
-        unknownCommands.forEach { errors.add("Unknown command: $it") }
+        if (unknownCommands.isNotEmpty()) {
+            errors.add("Unknown Commands: ${unknownCommands.joinToString(", ")}")
+        }
 
         return errors
     }


### PR DESCRIPTION
## Documentation Checker
As specified in the issue, on startup, it checks for if:

- there is a duplicate in the file
- there is a command that has no documentation
- there is an unknown command documented (e.g. something that did exist but was deleted)

and fails correspondingly, listing the changes that need to be made:

![](https://i.imgur.com/lY9tq3x.png)

**(some commands were duplicated locally just to test)**

Closes #52 

## Fix Descriptions
The description of the command was just not used in the help message:

### Before:
![](https://i.imgur.com/tV1CnzJ.png)

### Fixed:
![](https://i.imgur.com/X471Kfv.png)