### PR TITLE
Move/refactor + Add some tests for argument conversion

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/ArgumentConversion.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/ArgumentConversion.kt
@@ -1,0 +1,101 @@
+package me.aberrantfox.hotbot.commandframework
+
+import me.aberrantfox.hotbot.dsls.command.CommandArgument
+import me.aberrantfox.hotbot.dsls.command.CommandEvent
+import me.aberrantfox.hotbot.extensions.*
+
+enum class ArgumentType {
+    Integer, Double, Word, Choice, Manual, Sentence, User, Splitter, URL
+}
+
+val argsRequiredAtMessageEnd = listOf(ArgumentType.Sentence, ArgumentType.Splitter)
+
+/**
+ * Converts a list of strings to the matching expected argument types
+ *
+ * If the argument isn't converted, it is left as null;
+ * e.g. if it's optional and the actual args have already been fully converted
+ *
+ * Returns null if the actual args cannot fit into the expected ones;
+ * e.g. if there is still an arg to convert but no matching place to put it.
+ *
+ * @return A list of arguments converted to their expected type.
+ *
+ * null if the actual args do not fit into the expected ones.
+ *
+ */
+fun convertMainArgs(actual: List<String>,
+                    expected: List<CommandArgument>): List<Any?>? {
+
+    val converted = arrayOfNulls<Any?>(expected.size)
+
+    for (index in 0 until actual.size) {
+        val actualArg = actual[index]
+
+        val nextMatchingIndex = expected.withIndex().indexOfFirst {
+            matchesArgType(actualArg, it.value.type) && converted[it.index] == null
+        }
+        if (nextMatchingIndex == -1) return null
+
+        converted[nextMatchingIndex] = convertArg(actualArg, expected[nextMatchingIndex].type, index, actual)
+
+        if (expected[nextMatchingIndex].type in argsRequiredAtMessageEnd) break
+    }
+
+    if (converted.filterIndexed { i, arg -> arg == null && !expected[i].optional }.isNotEmpty())
+        return null
+
+    return converted.toList()
+}
+
+/**
+ * Converts any null arguments in a list of converted arguments to their default value
+ *
+ * If the default is a function, it is invoked, passing in the CommandEvent.
+ * If the value isn't null, it is left unmodified.
+ *
+ * @return A list of arguments with the optionals filled
+ *
+ */
+fun convertOptionalArgs(args: List<Any?>, expected: List<CommandArgument>, event: CommandEvent) =
+        args.mapIndexed { i, arg ->
+            arg ?: if (expected[i].defaultValue is Function<*>)
+                       (expected[i].defaultValue as (CommandEvent) -> Any).invoke(event)
+                   else
+                       expected[i].defaultValue
+        }
+
+
+private fun matchesArgType(arg: String, type: ArgumentType): Boolean {
+    return when (type) {
+        ArgumentType.Integer -> arg.isInteger()
+        ArgumentType.Double -> arg.isDouble()
+        ArgumentType.Choice -> arg.isBooleanValue()
+        ArgumentType.URL -> arg.containsURl()
+        else -> true
+    }
+}
+
+private fun convertArg(arg: String, type: ArgumentType, index: Int, actual: List<String>): Any {
+    return when (type) {
+        ArgumentType.Integer -> arg.toInt()
+        ArgumentType.Double -> arg.toDouble()
+        ArgumentType.Choice -> arg.toBooleanValue()
+        ArgumentType.User -> arg
+        ArgumentType.Sentence -> joinArgs(index, actual)
+        ArgumentType.Splitter -> splitArg(index, actual)
+        else -> arg
+    }
+}
+
+
+private fun joinArgs(start: Int, actual: List<String>) = actual.subList(start, actual.size).reduce { a, b -> "$a $b" }
+
+private fun splitArg(start: Int, actual: List<String>): List<String> {
+    val joined = joinArgs(start, actual)
+
+    if (!(joined.contains(seperatorCharacter))) return listOf(joined)
+
+    return joined.split(seperatorCharacter).toList()
+}
+

--- a/src/test/kotlin/me/aberrantfox/hotbot/commandframework/InvalidArgumentConversionTest.kt
+++ b/src/test/kotlin/me/aberrantfox/hotbot/commandframework/InvalidArgumentConversionTest.kt
@@ -1,0 +1,67 @@
+package me.aberrantfox.hotbot.commandframework
+
+import me.aberrantfox.hotbot.commandframework.ArgumentType.*
+import me.aberrantfox.hotbot.commandframework.ArgumentType.Double
+import me.aberrantfox.hotbot.dsls.command.CommandArgument
+import me.aberrantfox.hotbot.dsls.command.arg
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+
+class InvalidArgumentConversionTest {
+
+    // test(input args, expected args)
+
+    private val invalidSingleTypeArgs = listOf(
+            test(emptyList(), listOf(arg(Integer))),
+            test(emptyList(), listOf(arg(Sentence))),
+            test(emptyList(), listOf(arg(Splitter))),
+
+            test(listOf("hello"), listOf(arg(Integer))),
+            test(listOf("test"), listOf(arg(Double))),
+            test(listOf("5123"), listOf(arg(Choice))),
+            test(listOf("ajaslkdas"), listOf(arg(URL)))
+    )
+
+    private val invalidComboArgs = listOf(
+            test(listOf("5"), listOf(arg(Integer), arg(Sentence))),
+            test(listOf("f"), listOf(arg(Choice), arg(Splitter))),
+
+            test(listOf("124", "832.23482"), listOf(arg(Integer), arg(URL), arg(Double))),
+            test(listOf("921.25", "woaskpdas", "asdasd", "asdasd"), listOf(arg(Double), arg(Word), arg(Word))),
+            test(listOf("word", "91293", "41.2"), listOf(arg(Double), arg(Word), arg(Integer))),
+            test(listOf("402868974108409867"), listOf(arg(User), arg(Word))),
+
+            test(emptyList(), listOf(arg(Word), arg(Integer), arg(User)))
+    )
+
+    private val invalidOptionalArgs = listOf(
+            test(emptyList(), listOf(arg(Integer), arg(Word, true, "asdads"))),
+
+            test(listOf("adasd"), listOf(arg(Integer, true, 42))),
+            test(listOf("hello", "test", "123"), listOf(arg(Integer), arg(Sentence, true, "asjodaspd asd"))),
+            test(listOf("404665584274505728", "5"), listOf(arg(User), arg(Integer, true, 12), arg(Sentence))),
+            test(listOf("test"), listOf(arg(Integer, true, 54), arg(Double))),
+            test(listOf("kdas"), listOf(arg(Integer, true, 52), arg(Double, true, 25.2), arg(Word), arg(Word))),
+
+            test(listOf("4", "akdasd", "2"), listOf(arg(Integer, true, 24), arg(Double), arg(Splitter)))
+    )
+
+    @TestFactory
+    fun testInvalidSingleTypeArgs() = mapInvalidTest(invalidSingleTypeArgs)
+
+    @TestFactory
+    fun testInvalidComboArgs() = mapInvalidTest(invalidComboArgs)
+
+    @TestFactory
+    fun testInvalidOptionalArgs() = mapInvalidTest(invalidOptionalArgs)
+
+    private fun mapInvalidTest(argData: List<Pair<List<String>, List<CommandArgument>>>) =
+            argData.map { (input, expected) ->
+                DynamicTest.dynamicTest("Input $input against ${expected.map { Pair(it.type, it.optional) }} should cause a null return") {
+                    Assertions.assertNull(convertMainArgs(input, expected))
+                }
+            }
+
+    private fun test(input: List<String>, expectedArgs: List<CommandArgument>) = input to expectedArgs
+}

--- a/src/test/kotlin/me/aberrantfox/hotbot/commandframework/ValidArgumentConversionTest.kt
+++ b/src/test/kotlin/me/aberrantfox/hotbot/commandframework/ValidArgumentConversionTest.kt
@@ -1,0 +1,102 @@
+package me.aberrantfox.hotbot.commandframework
+
+import me.aberrantfox.hotbot.commandframework.ArgumentType.*
+import me.aberrantfox.hotbot.commandframework.ArgumentType.Double
+import me.aberrantfox.hotbot.dsls.command.CommandArgument
+import me.aberrantfox.hotbot.dsls.command.arg
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+
+class ValidArgumentConversionTest {
+
+    // test(input args, expected args, expected result)
+
+    private val validSingleTypeArgs = listOf(
+            test(emptyList(), emptyList(), emptyList()),
+
+            test(listOf("98"), listOf(arg(Integer)), listOf(98)),
+            test(listOf("832.8235"), listOf(arg(Double)), listOf(832.8235)),
+            test(listOf("AWordHere"), listOf(arg(Word)), listOf("AWordHere")),
+            test(listOf("402546539849056267"), listOf(arg(User)), listOf("402546539849056267")),
+
+            test(listOf("this is a load of text that shouldn't be modified"),
+                    listOf(arg(Manual)),
+                    listOf("this is a load of text that shouldn't be modified")),
+
+            test(listOf("5", "23#", "this", "is", "a", "test", "sentence", "5", "2k31o23", "asd"),
+                    listOf(arg(Sentence)),
+                    listOf("5 23# this is a test sentence 5 2k31o23 asd")),
+
+            test(listOf("Question", "with", "words", "?|", "asdjop", "asjkdoasdp", "|", "asldpasd", "as"),
+                    listOf(arg(Splitter)),
+                    listOf(listOf("Question with words ?", " asdjop asjkdoasdp ", " asldpasd as"))),
+
+            test(listOf("https://i.imgur.com/t2atGQL.jpg"),
+                    listOf(arg(URL)),
+                    listOf("https://i.imgur.com/t2atGQL.jpg")),
+
+            test(listOf("true", "false", "f", "t"),
+                    listOf(arg(Choice), arg(Choice), arg(Choice), arg(Choice)),
+                    listOf(true, false, false, true))
+    )
+
+    private val validComboArgs = listOf(
+            test(listOf("124", "https://github.com/AberrantFox/hotbot", "832.23482"),
+                    listOf(arg(Integer), arg(URL), arg(Double)),
+                    listOf(124, "https://github.com/AberrantFox/hotbot", 832.23482)),
+
+            test(listOf("wordjasidkashere", "f", "a", "question", "?|yes|no|Maybe"),
+                    listOf(arg(Word), arg(Choice), arg(Splitter)),
+                    listOf("wordjasidkashere", false, listOf("a question ?", "yes", "no", "Maybe"))),
+
+            test(listOf("402868974108409867", "message", "with", "spaces", "test", "sentence"),
+                    listOf(arg(User), arg(Sentence)),
+                    listOf("402868974108409867", "message with spaces test sentence"))
+    )
+
+    private val validOptionalArgs = listOf(
+            test(listOf("404665584274505728", "ajkdlsajd", "sentence", "from", "hereon", "52", "asd"),
+                    listOf(arg(User), arg(Integer, true, 1), arg(Sentence)),
+                    listOf("404665584274505728", null, "ajkdlsajd sentence from hereon 52 asd")),
+
+            test(emptyList(),
+                    listOf(arg(Word, true, "qweuiop")),
+                    listOf(null)),
+
+            test(listOf("23"),
+                    listOf(arg(Integer, true, 49)),
+                    listOf(23)),
+
+            test(listOf("wordjaskdas"),
+                    listOf(arg(Integer, true, 28), arg(Word)),
+                    listOf(null, "wordjaskdas")),
+
+            test(listOf("13", "asdjkasld", "asjdoaspdj", "no"),
+                    listOf(arg(Integer), arg(Integer, true, 18), arg(Sentence)),
+                    listOf(13, null, "asdjkasld asjdoaspdj no")),
+
+            test(listOf("true", "is", "no?|yes|no|maybe|off"),
+                    listOf(arg(Choice), arg(Choice, true, true), arg(Splitter)),
+                    listOf(true, null, listOf("is no?", "yes", "no", "maybe", "off")))
+    )
+
+    @TestFactory
+    fun testValidSingleTypeArgs() = mapValidTests(validSingleTypeArgs)
+
+    @TestFactory
+    fun testValidComboArgs() = mapValidTests(validComboArgs)
+
+    @TestFactory
+    fun testValidOptionalArgs() = mapValidTests(validOptionalArgs)
+
+    private fun mapValidTests(argData: List<Pair<List<String>, Pair<List<CommandArgument>, List<Any?>>>>) =
+            argData.map { (input, expected) ->
+                DynamicTest.dynamicTest(
+                        "Input $input should parse to ${expected.second}") {
+                    Assertions.assertEquals(expected.second, convertMainArgs(input, expected.first))
+                }
+            }
+
+    private fun test(input: List<String>, expectedArgs: List<CommandArgument>, expectedResult: List<Any?> = emptyList()) = input to Pair(expectedArgs, expectedResult)
+}

--- a/src/test/kotlin/me/aberrantfox/hotbot/extensions/InviteMatchTest.kt
+++ b/src/test/kotlin/me/aberrantfox/hotbot/extensions/InviteMatchTest.kt
@@ -1,6 +1,5 @@
-package me.aberrantfox.aegus.extenstions
+package me.aberrantfox.hotbot.extensions
 
-import me.aberrantfox.hotbot.extensions.containsInvite
 import net.dv8tion.jda.core.MessageBuilder
 import org.junit.Assert
 import org.junit.Test

--- a/src/test/kotlin/me/aberrantfox/hotbot/extensions/UrlMatchTest.kt
+++ b/src/test/kotlin/me/aberrantfox/hotbot/extensions/UrlMatchTest.kt
@@ -1,6 +1,5 @@
-package me.aberrantfox.aegus.extenstions
+package me.aberrantfox.hotbot.extensions
 
-import me.aberrantfox.hotbot.extensions.containsURL
 import org.junit.Assert
 import org.junit.Test
 

--- a/src/test/kotlin/me/aberrantfox/hotbot/security/NewPlayerTrackerTest.kt
+++ b/src/test/kotlin/me/aberrantfox/hotbot/security/NewPlayerTrackerTest.kt
@@ -1,4 +1,4 @@
-package me.aberrantfox.aegus.security
+package me.aberrantfox.hotbot.security
 
 import me.aberrantfox.hotbot.listeners.antispam.NewPlayers
 import org.joda.time.DateTime


### PR DESCRIPTION
## Changes
There aren't any outward changes, just to the code. 

I moved the things to do with argument conversion to a separate file and split the main function into one that converts the arguments and returns null if there's an error, and another to just convert the optionals (nulls) in a list of converted arguments. This makes it easier to test the conversion as you don't have to deal with the CommandEvent object to test the main part (which doesn't even use it anyway).

After the splitter not working when I added optional args, I thought I should probably add some tests, in case of any future changes, so things like that are caught. I'm not really sure what good tests should look like, but I tried to cover the main possibilities without making the tests too easily broken. 