### PR TITLE
Store muted members in DB instead of CFG

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
@@ -1,10 +1,11 @@
 package me.aberrantfox.hotbot
 
 import me.aberrantfox.hotbot.commandframework.produceContainer
+import me.aberrantfox.hotbot.database.getAllMutedMembers
 import me.aberrantfox.hotbot.database.loadUpManager
 import me.aberrantfox.hotbot.extensions.hasRole
 import me.aberrantfox.hotbot.extensions.timeToDifference
-import me.aberrantfox.hotbot.extensions.unmute
+import me.aberrantfox.hotbot.extensions.scheduleUnmute
 import me.aberrantfox.hotbot.listeners.*
 import me.aberrantfox.hotbot.listeners.antispam.DuplicateMessageListener
 import me.aberrantfox.hotbot.listeners.antispam.InviteListener
@@ -100,13 +101,13 @@ private fun handleRole(guild: Guild, roleName: String) {
 }
 
 private fun handleLTSMutes(config: Configuration, jda: JDA) {
-    config.security.mutedMembers.forEach {
+    getAllMutedMembers().forEach {
         val difference = timeToDifference(it.unmuteTime)
         val guild = jda.getGuildById(it.guildId)
         val user = guild.getMemberById(it.user)
 
         if(user != null) {
-            unmute(guild, user.user, config, difference, it)
+            scheduleUnmute(guild, user.user, config, difference, it)
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/MutedMemberTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/MutedMemberTransactions.kt
@@ -1,0 +1,43 @@
+package me.aberrantfox.hotbot.database
+
+import me.aberrantfox.hotbot.extensions.MuteRecord
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+
+
+fun insertMutedMember(record: MuteRecord) =
+    transaction {
+        MutedMember.insert {
+            it[MutedMember.unmuteTime] = record.unmuteTime
+            it[MutedMember.reason] = record.reason
+            it[MutedMember.moderator] = record.moderator
+            it[MutedMember.member] = record.user
+            it[MutedMember.guildId] = record.guildId
+        }
+    }
+
+fun deleteMutedMember(record: MuteRecord) =
+    transaction {
+        MutedMember.deleteWhere {
+            Op.build {
+                (MutedMember.member eq record.user) and (MutedMember.guildId eq record.guildId)
+            }
+        }
+    }
+
+fun getAllMutedMembers() =
+    transaction {
+        val mutedMembers = mutableListOf<MuteRecord>()
+        val membersInDb = MutedMember.selectAll()
+
+        membersInDb.forEach {
+            mutedMembers.add(MuteRecord(
+                    it[MutedMember.unmuteTime],
+                    it[MutedMember.reason],
+                    it[MutedMember.moderator],
+                    it[MutedMember.member],
+                    it[MutedMember.guildId]
+            ))
+        }
+        mutedMembers
+    }

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/NotesTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/NotesTransactions.kt
@@ -1,6 +1,5 @@
 package me.aberrantfox.hotbot.database
 
-import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.select

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/SetupOperations.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/SetupOperations.kt
@@ -27,7 +27,7 @@ fun setupDatabaseSchema(config: Configuration) {
     )
 
     transaction {
-        SchemaUtils.create(Strikes, Suggestions, BanRecords, CommandPermissions, ChannelResources, Notes)
+        SchemaUtils.create(Strikes, Suggestions, BanRecords, CommandPermissions, ChannelResources, Notes, MutedMember)
         logger.addLogger(StdOutSqlLogger)
     }
 }
@@ -75,4 +75,13 @@ object ChannelResources : Table() {
     val channel = varchar("channel", 18)
     val section = varchar("section", 64)
     val info = varchar("info", 255)
+}
+
+object MutedMember : Table() {
+    val id = integer("id").autoIncrement().primaryKey()
+    val member = varchar("member", 18)
+    val unmuteTime = long("unmuteTime")
+    val reason = text("reason")
+    val moderator = varchar("moderator", 18)
+    val guildId = varchar("guildId", 18)
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
@@ -1,5 +1,7 @@
 package me.aberrantfox.hotbot.extensions
 
+import me.aberrantfox.hotbot.database.deleteMutedMember
+import me.aberrantfox.hotbot.database.insertMutedMember
 import me.aberrantfox.hotbot.dsls.embed.embed
 import me.aberrantfox.hotbot.services.Configuration
 import net.dv8tion.jda.core.JDA
@@ -66,8 +68,8 @@ fun muteMember(guild: Guild, user: User, time: Long, reason: String, config: Con
         val muteEmbed = buildMuteEmbed(user.asMention, timeString, reason)
         it.sendMessage(muteEmbed).queue()
 
-        config.security.mutedMembers.add(record)
-        unmute(guild, user, config, time, record)
+        insertMutedMember(record)
+        scheduleUnmute(guild, user, config, time, record)
     }
 
     moderator.openPrivateChannel().queue {
@@ -96,7 +98,7 @@ private fun buildMuteEmbed(userMention: String, timeString: String, reason: Stri
             setColor(Color.RED)
         }
 
-fun unmute(guild: Guild, user: User, config: Configuration, time: Long, muteRecord: MuteRecord) {
+fun scheduleUnmute(guild: Guild, user: User, config: Configuration, time: Long, muteRecord: MuteRecord) {
     if (time <= 0) {
         removeMuteRole(guild, user, config, muteRecord)
         return
@@ -111,11 +113,11 @@ fun unmute(guild: Guild, user: User, config: Configuration, time: Long, muteReco
 
 fun removeMuteRole(guild: Guild, user: User, config: Configuration, record: MuteRecord) {
     if (user.mutualGuilds.isEmpty()) {
-        config.security.mutedMembers.remove(record)
+        deleteMutedMember(record)
         return
     }
 
-    config.security.mutedMembers.remove(record)
+    deleteMutedMember(record)
     removeMuteRole(guild, user, config)
 }
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/services/Configuration.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/services/Configuration.kt
@@ -2,7 +2,6 @@ package me.aberrantfox.hotbot.services
 
 import com.github.salomonbrys.kotson.fromJson
 import com.google.gson.Gson
-import me.aberrantfox.hotbot.extensions.MuteRecord
 import me.aberrantfox.hotbot.logging.ChannelIdHolder
 import java.io.File
 import java.util.*
@@ -23,7 +22,6 @@ data class ServerInformation(val token: String = "insert-token",
                              val suggestionPoolLimit: Int = 20)
 
 data class Security(val ignoredIDs: MutableSet<String> = mutableSetOf(),
-                    val mutedMembers: ArrayList<MuteRecord> = ArrayList(),
                     var lockDownMode: Boolean = false,
                     val infractionActionMap: HashMap<Int, InfractionAction> = HashMap(),
                     val mutedRole: String = "Muted",


### PR DESCRIPTION
Includes a rename of a method "unmute" to "scheduleUnmute" (which is what it does).