### PR TITLE
Bug Fixes

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
@@ -41,6 +41,8 @@ fun main(args: Array<String>) {
     val jda = JDABuilder(AccountType.BOT).setToken(config.serverInformation.token).buildBlocking()
     val logger = convertChannels(config.logChannels, jda)
 
+    jda.guilds.forEach { setupMutedRole(it, config.security.mutedRole) }
+
     logger.info("connected")
     val mutedRole = jda.getRolesByName(config.security.mutedRole, true).first()
     val tracker = MessageTracker(1)
@@ -71,19 +73,14 @@ fun main(args: Array<String>) {
     }
 
     jda.presence.setPresence(OnlineStatus.ONLINE, Game.of("${config.serverInformation.prefix}help"))
-    jda.guilds.forEach { setupMutedRole(it, config.security.mutedRole) }
+
 
     handleLTSMutes(config, jda)
     logger.info("Fully setup, now ready for use.")
 }
 
 private fun setupMutedRole(guild: Guild, roleName: String) {
-    if (!guild.hasRole(roleName)) {
-        guild.controller.createRole().setName(roleName).queue {
-            handleRole(guild, roleName)
-        }
-        return
-    }
+    if (!guild.hasRole(roleName)) guild.controller.createRole().setName(roleName).complete()
 
     handleRole(guild, roleName)
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
@@ -92,7 +92,7 @@ private fun handleRole(guild: Guild, roleName: String) {
     val role = guild.getRolesByName(roleName, true).first()
 
     guild.textChannels.forEach {
-        val hasOverride = it.permissionOverrides.any {
+        val hasOverride = it.rolePermissionOverrides.any {
             it.role.name.toLowerCase() == roleName.toLowerCase()
         }
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/FunCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/FunCommands.kt
@@ -63,7 +63,7 @@ fun funCommands() =
 
                 val response = parseCowsayArgs(sentence.split(" "))
                 if(!response.isBlank()){
-                    it.respond(response)
+                    it.safeRespond(response)
                     return@execute
                 }
 
@@ -76,11 +76,11 @@ fun funCommands() =
                 if(!result.isBlank()){
                     val response = Cowsay.say(args)
                     if (response.length > 1994){
-                        it.respond("that message was too long, moo!")
+                        it.safeRespond("that message was too long, moo!")
                         return@execute
                     }
 
-                    it.respond("```" + Cowsay.say(args) + "```")
+                    it.safeRespond("```" + Cowsay.say(args) + "```")
                 }
             }
         }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/UtilityCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/UtilityCommands.kt
@@ -24,7 +24,7 @@ object Project {
     val properties: Properties
 
     init {
-        val propFile = Configuration::class.java.getResource(configPath("properties.json")).readText()
+        val propFile = Configuration::class.java.getResource("/properties.json").readText()
         val gson = Gson()
         properties = gson.fromJson(propFile, Properties::class.java)
     }

--- a/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/extensions/JDAUtility.kt
@@ -148,8 +148,12 @@ fun JDA.performActionIfIsID(id: String, action: (User) -> Unit) =
     }
 
 fun String.trimToID(): String =
-    if (this.startsWith("<@") && this.endsWith(">")) {
-        replace("<", "").replace(">", "").replace("@", "")
-    } else {
-        this
-    }
+        if (this.startsWith("<@") && this.endsWith(">")) {
+            replace("<", "")
+                    .replace(">", "")
+                    .replace("@", "")
+                    .replace("!", "") // Mentions with nicknames
+                    .replace("&", "") // Role mentions
+        } else {
+            this
+        }

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/DuplicateMessageListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/DuplicateMessageListener.kt
@@ -21,7 +21,7 @@ class DuplicateMessageListener (val config: Configuration, val log: BotLogger, v
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
         val time = DateTime.now()
 
-        if(event.member.roles.size > 0) return
+        if((event.member?.roles?.size ?: 0) > 0) return
         if(event.author.isBot) return
 
         val id = event.author.id

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/InviteListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/InviteListener.kt
@@ -33,9 +33,9 @@ class InviteListener(val config: Configuration, val logger: BotLogger) : Listene
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) =
             handlePossibleInviteMessage(event.member, event.message, event.guild, event.channel, event.author.isBot, event.jda)
 
-    private fun handlePossibleInviteMessage(author: Member, message: Message, guild: Guild, channel: TextChannel,
+    private fun handlePossibleInviteMessage(author: Member?, message: Message, guild: Guild, channel: TextChannel,
                                             isBot: Boolean, jda: JDA) {
-        if (isBot) return
+        if (isBot || author == null) return
 
         val id = author.user.id
         val highestRole = author.user.id.idToUser(message.jda).toMember(guild).getHighestRole()

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/TooManyMentionsListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/TooManyMentionsListener.kt
@@ -9,7 +9,7 @@ import net.dv8tion.jda.core.hooks.ListenerAdapter
 
 class TooManyMentionsListener(val log: BotLogger, val mutedRole: Role) : ListenerAdapter() {
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
-        if(event.member.roles.isNotEmpty()) return
+        if(event.member?.roles?.isNotEmpty() != false) return // either has roles or is null (WebHookMessage)
 
         if(event.message.mentionedUsers.size >= 7) {
             event.message.delete().queue()


### PR DESCRIPTION
## Fixes
- Sanitize `cowsay` mentions (use `safeRespond`)
- Trim mentions with nicknames correctly (Closes #82 )
- Check for null `event.member` (webhook messages -> null member)
- Only search `rolePermissionOverrides` when setting up the muted role, otherwise `role` could be null and an exception is thrown, stopping the bot from starting (member overrides -> null role)
- When creating the muted role (and it doesn't exist), use blocking `complete`, otherwise the bot won't start, because it tries to get the `first()` of an empty list. The role was also created *after* the bot tried to retrieve and use it, so I moved it above.
You had to manually create the role to stop the exception otherwise.
- Fix attempt to read `properties.json` from the `config` directory. Instead, read it as a resource, as before. 