### PR TITLE
Add updateEmbed command

### DIFF
--- a/config/help.json
+++ b/config/help.json
@@ -340,6 +340,13 @@
       "example": ""
     },
     {
+      "name": "updateEmbed",
+      "category": "embed",
+      "description": "Update the original message of the embed copied with copyembed.",
+      "structure": "",
+      "example": ""
+    },
+    {
       "name": "copyembed",
       "category": "embed",
       "description": "Copies the embed from the message with the given id into the embed builder. The channelId from which to get the embed is optional and will default to the one you invoked the command in.",

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
@@ -16,6 +16,7 @@ import java.time.Instant
 
 private object EHolder {
     var embed: EmbedBuilder = EmbedBuilder()
+    var message: Message? = null
 }
 
 private object FHolder {
@@ -29,6 +30,8 @@ fun embedCommands() =
         command("clearembed") {
             execute {
                 EHolder.embed = EmbedBuilder()
+                EHolder.message = null
+
                 it.respond("Embed cleared")
             }
         }
@@ -36,6 +39,33 @@ fun embedCommands() =
         command("sendembed") {
             execute {
                 it.respond(EHolder.embed.build())
+            }
+        }
+
+        command("updateEmbed") {
+            execute {
+                val message = EHolder.message
+
+                if (message == null || EHolder.embed.isEmpty) {
+                    it.respond("No embed currently copied.")
+                    return@execute
+                }
+
+                if (message.author != it.jda.selfUser) {
+                    it.respond("You can only edit messages sent by the bot.")
+                    return@execute
+                }
+
+                message.editMessage(EHolder.embed.build()).queue(
+                        { _ ->
+                            // Success
+                            it.respond("Embed updated.")
+                        },
+                        { _ ->
+                            // Failure
+                            it.respond("Failed to edit message. It may have been deleted.")
+                        }
+                )
             }
         }
 
@@ -68,6 +98,7 @@ fun embedCommands() =
                             }
 
                             EHolder.embed = EmbedBuilder(embed)
+                            EHolder.message = msg
                         },
                         { error ->
                             // Failure

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/EmbedCommands.kt
@@ -38,6 +38,11 @@ fun embedCommands() =
 
         command("sendembed") {
             execute {
+                if (EHolder.embed.isEmpty) {
+                    it.respond("No embed to send.")
+                    return@execute
+                }
+
                 it.respond(EHolder.embed.build())
             }
         }
@@ -57,12 +62,10 @@ fun embedCommands() =
                 }
 
                 message.editMessage(EHolder.embed.build()).queue(
-                        { _ ->
-                            // Success
+                        { embedMessage ->
                             it.respond("Embed updated.")
                         },
-                        { _ ->
-                            // Failure
+                        { error ->
                             it.respond("Failed to edit message. It may have been deleted.")
                         }
                 )


### PR DESCRIPTION
## Summary
I thought that the `copyembed` command is probably more useful if you don't have to delete and resend the messages, especially if it is an embed already between other messages, so I wrote this command to allow you to update the message with the new embed in-place. The message you initially copy with `copyembed` is the one that will get updated.

### Empty Embed Fix
If you tried to send an embed without having anything in it, an exception was thrown, so I also just added a check to prevent that.

## Images

![](http://storage9.static.itmages.com/i/18/0227/h_1519751049_2291590_735de1fd02.png)


![](http://storage2.static.itmages.com/i/18/0227/h_1519751100_9672263_d3458f797a.png)
