### PR TITLE
Suggestion Status Update DMs

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/SuggestionCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/SuggestionCommands.kt
@@ -7,12 +7,14 @@ import me.aberrantfox.hotbot.dsls.command.commands
 import me.aberrantfox.hotbot.extensions.stdlib.idToName
 import me.aberrantfox.hotbot.services.AddResponse
 import me.aberrantfox.hotbot.services.Configuration
-import me.aberrantfox.hotbot.services.PoolRecord
 import me.aberrantfox.hotbot.services.UserElementPool
 import me.aberrantfox.hotbot.database.*
+import me.aberrantfox.hotbot.dsls.embed.embed
+import me.aberrantfox.hotbot.services.PoolRecord
 import net.dv8tion.jda.core.EmbedBuilder
 import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.entities.Guild
+import sun.java2d.SunGraphicsEnvironment
 import java.awt.Color
 
 
@@ -78,8 +80,9 @@ fun suggestionCommands() = commands {
                 channel.id == it.config.messageChannels.suggestionChannel
             }
 
+
             channel?.sendMessage(buildSuggestionMessage(suggestion, it.jda, SuggestionStatus.Review).build())?.queue {
-                trackSuggestion(suggestion, SuggestionStatus.Review, it.id)
+                trackSuggestion(SuggestionRecord(it.id, SuggestionStatus.Review, suggestion))
 
                 it.addReaction("⬆").queue()
                 it.addReaction("⬇").queue()
@@ -125,7 +128,7 @@ fun suggestionCommands() = commands {
 
             channel.getMessageById(target).queue {
                 val suggestion = obtainSuggestion(target)
-                val message = buildSuggestionMessage(suggestion, it.jda, status)
+                val message = buildSuggestionMessage(suggestion.poolInfo, it.jda, status)
                 val reasonTitle = "Reason for Status"
 
                 message.fields.removeIf { it.name == reasonTitle }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/SuggestionCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/SuggestionCommands.kt
@@ -87,28 +87,6 @@ fun suggestionCommands() = commands {
         }
     }
 
-    command("poolaccept") {
-        execute {
-            val suggestion = Suggestions.pool.top()
-
-            if (suggestion == null) {
-                it.respond("The suggestion pool is empty... :)")
-                return@execute
-            }
-
-            val channel = it.guild.textChannels.findLast { channel ->
-                channel.id == it.config.messageChannels.suggestionChannel
-            }
-
-            channel?.sendMessage(buildSuggestionMessage(suggestion, it.jda, SuggestionStatus.Review).build())?.queue {
-                trackSuggestion(suggestion, SuggestionStatus.Review, it.id)
-
-                it.addReaction("⬆").queue()
-                it.addReaction("⬇").queue()
-            }
-        }
-    }
-
     command("pooldeny") {
         execute {
             val rejected = Suggestions.pool.top()

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/SuggestionTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/SuggestionTransactions.kt
@@ -4,16 +4,21 @@ import me.aberrantfox.hotbot.commandframework.commands.SuggestionStatus
 import me.aberrantfox.hotbot.services.PoolRecord
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.joda.time.DateTime
 
+data class SuggestionRecord(val messageID: String, val status: SuggestionStatus,
+                            val poolInfo: PoolRecord,
+                            val idea: String = poolInfo.message, val date: DateTime = poolInfo.dateTime,
+                            val member: String = poolInfo.sender, val avatarURL: String = poolInfo.avatarURL)
 
-fun trackSuggestion(suggestion: PoolRecord, status: SuggestionStatus, messageID: String) =
+fun trackSuggestion(suggestion: SuggestionRecord) =
         transaction {
             Suggestions.insert {
-                it[Suggestions.id] = messageID
-                it[Suggestions.date] = suggestion.dateTime
-                it[Suggestions.idea] = suggestion.message
-                it[Suggestions.member] = suggestion.sender
-                it[Suggestions.status] = status
+                it[Suggestions.id] = suggestion.messageID
+                it[Suggestions.date] = suggestion.date
+                it[Suggestions.idea] = suggestion.idea
+                it[Suggestions.member] = suggestion.member
+                it[Suggestions.status] = suggestion.status
                 it[Suggestions.avatarURL] = suggestion.avatarURL
             }
         }
@@ -38,7 +43,8 @@ fun obtainSuggestion(id: String) =
                 Op.build { Suggestions.id eq id }
             }.first()
 
-            PoolRecord(row[Suggestions.member], row[Suggestions.date], row[Suggestions.idea], row[Suggestions.avatarURL])
+            val poolInfo = PoolRecord(row[Suggestions.member], row[Suggestions.date], row[Suggestions.idea], row[Suggestions.avatarURL])
+            SuggestionRecord(row[Suggestions.id], row[Suggestions.status], poolInfo)
         }
 
 fun isTracked(id: String) =


### PR DESCRIPTION
## Summary
As per the issue, an embed is sent to the submitter when their suggestion has been responded to, detailing the ID, previous status, new status, suggestion message, and the response.

The general `PoolRecord` didn't contain the needed information, so I created a `SuggestionRecord` that has the same info (contains a `PoolRecord`) but also the suggestion specific details: the `messageID` and `status`.

There was also a duplicate `poolaccept` command that has been removed.

Closes #72 

## Image

![](http://i.imgur.com/ob788im.png)