### PR TITLE
Fix Null User Exceptions

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/CommandExecutor.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/CommandExecutor.kt
@@ -64,7 +64,7 @@ class CommandExecutor(val config: Configuration,
     private fun invokeCommand(command: Command, name: String, actual: List<String>, message: Message, author: User, invokedInGuild: Boolean) {
         val channel = message.channel
 
-        if( !(manager.canUseCommand(author.id, name)) ) {
+        if( !(manager.canUseCommand(author, name)) ) {
             channel.sendMessage("Did you really think I would let you do that? :thinking:").queue()
             return
         }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/ModerationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/ModerationCommands.kt
@@ -9,8 +9,8 @@ import me.aberrantfox.hotbot.extensions.jda.fullName
 import me.aberrantfox.hotbot.extensions.jda.isCommandInvocation
 import me.aberrantfox.hotbot.extensions.jda.performActionIfIsID
 import me.aberrantfox.hotbot.extensions.jda.sendPrivateMessage
-import me.aberrantfox.hotbot.extensions.stdlib.idToUser
 import me.aberrantfox.hotbot.extensions.stdlib.randomListItem
+import me.aberrantfox.hotbot.extensions.stdlib.retrieveIdToUser
 import me.aberrantfox.hotbot.extensions.stdlib.toRole
 import me.aberrantfox.hotbot.services.Configuration
 import me.aberrantfox.hotbot.utility.muteMember
@@ -212,7 +212,7 @@ fun moderationCommands() = commands {
                     val record = getReason(target)
 
                     if (record != null) {
-                        it.respond("$target was banned by ${record.mod.idToUser(it.jda).fullName()} for reason ${record.reason}")
+                        it.respond("$target was banned by ${record.mod.retrieveIdToUser(it.jda).fullName()} for reason ${record.reason}")
                     } else {
                         it.respond("That user does not have a record logged.")
                     }
@@ -266,7 +266,7 @@ fun moderationCommands() = commands {
                 "Please change it within the next 30 minutes or you will be banned.")
 
             Timer().schedule(1000 * 60 * 30) {
-                if(avatar == it.jda.getUserById(user.id).effectiveAvatarUrl) {
+                if(avatar == user.id.retrieveIdToUser(it.jda).effectiveAvatarUrl) {
                     user.sendPrivateMessage("Hi, since you failed to change your profile picture, you are being banned.")
                     Timer().schedule(1000 * 10) {
                         it.guild.controller.ban(user, 1, "Having a bad profile picture and refusing to change it.").queue()

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/PermissionsCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/PermissionsCommands.kt
@@ -134,7 +134,7 @@ fun permissionCommands() =
             execute {
                 val available = HelpConf.listCategories().map { cat ->
                     val cmds =  HelpConf.listCommandsinCategory(cat)
-                        .filter { cmd -> it.manager.canUseCommand(it.author.id, cmd.name) }
+                        .filter { cmd -> it.manager.canUseCommand(it.author, cmd.name) }
                         .map(CommandDescriptor::name)
                         .joinToString()
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/ProfilesCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/ProfilesCommands.kt
@@ -3,7 +3,7 @@ package me.aberrantfox.hotbot.commandframework.commands
 import me.aberrantfox.hotbot.commandframework.parsing.ArgumentType
 import me.aberrantfox.hotbot.dsls.command.CommandSet
 import me.aberrantfox.hotbot.dsls.command.commands
-import me.aberrantfox.hotbot.extensions.stdlib.idToName
+import me.aberrantfox.hotbot.extensions.stdlib.retrieveIdToName
 import me.aberrantfox.hotbot.services.AddResponse
 import me.aberrantfox.hotbot.services.UserElementPool
 
@@ -57,7 +57,7 @@ fun profileCommands() = commands {
             target.sendMessage(
                 record.prettyPrint(it.jda, "Profile")
                     .setTitle("")
-                    .setAuthor(record.sender.idToName(it.jda), record.avatarURL, record.avatarURL)
+                    .setAuthor(record.sender.retrieveIdToName(it.jda), record.avatarURL, record.avatarURL)
                     .build())
                 .queue()
         }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/RaidCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/RaidCommands.kt
@@ -52,7 +52,10 @@ fun raidCommands() = commands {
                 return@execute
             }
 
-            MutedRaiders.set.forEach { id -> removeMuteRole(it.guild, id.idToUser(it.jda), it.config) }
+            MutedRaiders.set
+                    .mapNotNull { id -> id.idToUser(it.jda) }
+                    .forEach { user -> removeMuteRole(it.guild, user, it.config) }
+
             MutedRaiders.set.clear()
             it.respond("Raiders unmuted, be nice bois!")
         }
@@ -87,6 +90,8 @@ fun raidCommands() = commands {
             MutedRaiders.set
                     .map { id -> id.retrieveIdToUser(it.jda) }
                     .forEach { user -> it.guild.controller.ban(user, delDays).queue() }
+
+            MutedRaiders.set.clear()
 
             it.respond("Performing raid ban.")
         }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/RaidCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/RaidCommands.kt
@@ -5,6 +5,7 @@ import me.aberrantfox.hotbot.dsls.command.CommandSet
 import me.aberrantfox.hotbot.dsls.command.commands
 import me.aberrantfox.hotbot.extensions.jda.fullName
 import me.aberrantfox.hotbot.extensions.stdlib.idToUser
+import me.aberrantfox.hotbot.extensions.stdlib.retrieveIdToUser
 import me.aberrantfox.hotbot.listeners.antispam.MutedRaiders
 import me.aberrantfox.hotbot.utility.removeMuteRole
 import net.dv8tion.jda.core.entities.User
@@ -84,8 +85,8 @@ fun raidCommands() = commands {
             }
 
             MutedRaiders.set
-                .map { id -> id.idToUser(it.jda) }
-                .forEach { user -> it.guild.controller.ban(user, delDays).queue() }
+                    .map { id -> id.retrieveIdToUser(it.jda) }
+                    .forEach { user -> it.guild.controller.ban(user, delDays).queue() }
 
             it.respond("Performing raid ban.")
         }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -193,7 +193,7 @@ fun strikeCommands() =
 
         command("selfhistory") {
             execute {
-                val target = it.author.id.idToUser(it.jda)
+                val target = it.author
 
                 target.sendPrivateMessage(buildHistoryEmbed(target, false, getHistory(target.id),
                         null, it))

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -10,10 +10,7 @@ import me.aberrantfox.hotbot.dsls.embed.embed
 import me.aberrantfox.hotbot.extensions.jda.fullName
 import me.aberrantfox.hotbot.extensions.jda.getMemberJoinString
 import me.aberrantfox.hotbot.extensions.jda.sendPrivateMessage
-import me.aberrantfox.hotbot.extensions.stdlib.formatJdaDate
-import me.aberrantfox.hotbot.extensions.stdlib.idToName
-import me.aberrantfox.hotbot.extensions.stdlib.idToUser
-import me.aberrantfox.hotbot.extensions.stdlib.limit
+import me.aberrantfox.hotbot.extensions.stdlib.*
 import me.aberrantfox.hotbot.services.Configuration
 import me.aberrantfox.hotbot.services.InfractionAction
 import me.aberrantfox.hotbot.services.UserID
@@ -313,7 +310,7 @@ private fun buildHistoryEmbed(target: User, includeModerator: Boolean, records: 
                     inline = false
 
                     if(includeModerator) {
-                        value += "\nIssued by **${record.moderator.idToName(it.jda)}** on **${record.dateTime.toString(DateTimeFormat.forPattern("dd/MM/yyyy"))}**"
+                        value += "\nIssued by **${record.moderator.retrieveIdToName(it.jda)}** on **${record.dateTime.toString(DateTimeFormat.forPattern("dd/MM/yyyy"))}**"
                     }
                 }
 
@@ -348,7 +345,7 @@ private fun buildHistoryEmbed(target: User, includeModerator: Boolean, records: 
 
             notes.forEach { note ->
                 field {
-                    name = "ID :: __${note.id}__ :: Staff :: __${note.moderator.idToName(it.jda)}__"
+                    name = "ID :: __${note.id}__ :: Staff :: __${note.moderator.retrieveIdToName(it.jda)}__"
                     value = "Noted on **${note.dateTime.toString(DateTimeFormat.forPattern("dd/MM/yyyy"))}**"
                     inline = false
                 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/SuggestionCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/SuggestionCommands.kt
@@ -3,14 +3,14 @@ package me.aberrantfox.hotbot.commandframework.commands
 import me.aberrantfox.hotbot.commandframework.parsing.ArgumentType
 import me.aberrantfox.hotbot.dsls.command.CommandSet
 import me.aberrantfox.hotbot.dsls.command.commands
-import me.aberrantfox.hotbot.extensions.stdlib.idToName
 import me.aberrantfox.hotbot.services.AddResponse
 import me.aberrantfox.hotbot.services.Configuration
 import me.aberrantfox.hotbot.services.UserElementPool
 import me.aberrantfox.hotbot.database.*
 import me.aberrantfox.hotbot.dsls.embed.embed
 import me.aberrantfox.hotbot.extensions.jda.sendPrivateMessage
-import me.aberrantfox.hotbot.extensions.stdlib.idToUser
+import me.aberrantfox.hotbot.extensions.stdlib.retrieveIdToName
+import me.aberrantfox.hotbot.extensions.stdlib.retrieveIdToUser
 import me.aberrantfox.hotbot.services.PoolRecord
 import net.dv8tion.jda.core.EmbedBuilder
 import net.dv8tion.jda.core.JDA
@@ -132,7 +132,7 @@ fun suggestionCommands() = commands {
                 val reasonTitle = "Reason for Status"
 
                 val suggestionUpdateMessage = buildSuggestionUpdateEmbed(suggestion, reason, status)
-                suggestion.member.idToUser(it.jda).sendPrivateMessage(suggestionUpdateMessage)
+                suggestion.member.retrieveIdToUser(it.jda).sendPrivateMessage(suggestionUpdateMessage)
 
                 message.fields.removeIf { it.name == reasonTitle }
 
@@ -186,7 +186,7 @@ private fun buildSuggestionUpdateEmbed(suggestion: SuggestionRecord, response: S
 
 private fun buildSuggestionMessage(suggestion: PoolRecord, jda: JDA, status: SuggestionStatus) =
     EmbedBuilder()
-        .setTitle("${suggestion.sender.idToName(jda)}'s Suggestion")
+        .setTitle("${suggestion.sender.retrieveIdToName(jda)}'s Suggestion")
         .setThumbnail(suggestion.avatarURL)
         .setColor(status.colour)
         .setDescription(suggestion.message)

--- a/src/main/kotlin/me/aberrantfox/hotbot/extensions/stdlib/StringExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/extensions/stdlib/StringExtensions.kt
@@ -61,8 +61,10 @@ fun String.toBooleanValue(): Boolean =
         }
 
 fun String.idToName(jda: JDA): String = jda.getUserById(this).name
+fun String.idToUser(jda: JDA): User? = jda.getUserById(this.trimToID())
 
-fun String.idToUser(jda: JDA): User = jda.getUserById(this.trimToID())
+fun String.retrieveIdToUser(jda: JDA): User = jda.retrieveUserById(this.trimToID()).complete()
+fun String.retrieveIdToName(jda: JDA): String = jda.retrieveUserById(this.trimToID()).complete().name
 
 fun String.toRole(guild: Guild): Role? = guild.getRoleById(this)
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/InviteListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/InviteListener.kt
@@ -3,7 +3,6 @@ package me.aberrantfox.hotbot.listeners.antispam
 import me.aberrantfox.hotbot.extensions.jda.deleteIfExists
 import me.aberrantfox.hotbot.extensions.jda.fullName
 import me.aberrantfox.hotbot.extensions.stdlib.containsInvite
-import me.aberrantfox.hotbot.extensions.stdlib.idToName
 import me.aberrantfox.hotbot.logging.BotLogger
 import me.aberrantfox.hotbot.permissions.PermissionManager
 import me.aberrantfox.hotbot.services.Configuration
@@ -58,7 +57,8 @@ class InviteListener(val config: Configuration, val logger: BotLogger, val manag
                 guild.controller.ban(author, 0, "You've been automatically banned for linking invitations. Advertising is not allowed, sorry.").queue {
                     logger.alert("Banned user: ${author.fullName()} ($id for advertising automatically.")
                 }
-                logger.alert("Banned: ${id.idToName(jda)} for ${RecentInvites.value(id)} invites.")
+
+                logger.alert("Banned: ${author.fullName()} for ${RecentInvites.value(id)} invites.")
                 RecentInvites.cache.map.remove(id)
             }
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/NewJoinListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/NewJoinListener.kt
@@ -1,7 +1,7 @@
 package me.aberrantfox.hotbot.listeners.antispam
 
 
-import me.aberrantfox.hotbot.extensions.stdlib.idToName
+import me.aberrantfox.hotbot.extensions.stdlib.retrieveIdToName
 import me.aberrantfox.hotbot.services.DateTracker
 import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.events.guild.member.GuildMemberJoinEvent
@@ -10,7 +10,7 @@ import org.joda.time.DateTime
 
 object NewPlayers {
     val cache = DateTracker(12)
-    fun names(jda: JDA) = cache.keyList().map { it.idToName(jda) }
+    fun names(jda: JDA) = cache.keyList().map { it.retrieveIdToName(jda) }
 }
 
 class NewJoinListener : ListenerAdapter() {

--- a/src/main/kotlin/me/aberrantfox/hotbot/permissions/PermissionsManagement.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/permissions/PermissionsManagement.kt
@@ -4,10 +4,8 @@ import me.aberrantfox.hotbot.database.savePermissions
 import me.aberrantfox.hotbot.extensions.jda.getHighestRole
 import me.aberrantfox.hotbot.extensions.jda.isEqualOrHigherThan
 import me.aberrantfox.hotbot.extensions.jda.toMember
-import me.aberrantfox.hotbot.extensions.stdlib.idToUser
 import me.aberrantfox.hotbot.extensions.stdlib.toRole
 import me.aberrantfox.hotbot.services.Configuration
-import me.aberrantfox.hotbot.services.UserID
 import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.entities.Role
 import net.dv8tion.jda.core.entities.User
@@ -46,10 +44,10 @@ data class PermissionManager(val map: HashMap<RoleID, HashSet<CommandName>> = Ha
         return highestRole?.isEqualOrHigherThan(actionRole) ?: false
     }
 
-    fun canUseCommand(userId: UserID, commandName: CommandName): Boolean {
-        if(userId == config.serverInformation.ownerID) return true
+    fun canUseCommand(user: User, commandName: CommandName): Boolean {
+        if(user.id == config.serverInformation.ownerID) return true
 
-        val highestRole = userId.idToUser(jda).toMember(jda.getGuildById(config.serverInformation.guildid)).getHighestRole()
+        val highestRole = user.toMember(jda.getGuildById(config.serverInformation.guildid)).getHighestRole()
         val roles = getAllRelevantRoleIds(highestRole?.id)
 
         return roles.map { map[it] }

--- a/src/main/kotlin/me/aberrantfox/hotbot/services/PoolToChannelService.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/services/PoolToChannelService.kt
@@ -3,7 +3,7 @@ package me.aberrantfox.hotbot.services
 import com.fatboyindustrial.gsonjodatime.Converters
 import com.google.common.reflect.TypeToken
 import com.google.gson.GsonBuilder
-import me.aberrantfox.hotbot.extensions.stdlib.idToName
+import me.aberrantfox.hotbot.extensions.stdlib.retrieveIdToName
 import net.dv8tion.jda.core.EmbedBuilder
 import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.entities.MessageEmbed
@@ -17,7 +17,7 @@ import java.util.*
 data class PoolRecord(val sender: String, val dateTime: DateTime, val message: String, val avatarURL: String) {
     fun describe(jda: JDA, datumName: String): MessageEmbed =
         EmbedBuilder()
-            .setTitle("$datumName by ${sender.idToName(jda)}")
+            .setTitle("$datumName by ${sender.retrieveIdToName(jda)}")
             .setDescription(message)
             .addField("Time of Creation", formatConstructionDate(), false)
             .addField("Member ID", sender, false)
@@ -25,7 +25,7 @@ data class PoolRecord(val sender: String, val dateTime: DateTime, val message: S
 
     fun prettyPrint(jda: JDA, datumName: String): EmbedBuilder =
         EmbedBuilder()
-            .setTitle("${sender.idToName(jda)}'s $datumName")
+            .setTitle("${sender.retrieveIdToName(jda)}'s $datumName")
             .addField("Time of Creation", formatConstructionDate(), false)
             .addField("Content", message, false)
             .setThumbnail(avatarURL)


### PR DESCRIPTION
## Summary
- Where needed, replace `idToUser` and `idToName`, which use `getUserById`, with `retrieveIdToUser` and `retrieveIdToName`, which use `retrieveUserById`, preventing null being returned and an exception being thrown when the user is no longer a member of the server.

- Remove redundant ID to user conversions; e.g.
`val target = it.author.id.idToUser(it.jda)` -> `val target = it.author`

- Use the `User` object as a parameter to `canUseCommand` instead of receiving an ID and converting it anyway. 

Closes #95 