### PR TITLE
Removed debug messages in strikeRequests

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -114,7 +114,6 @@ fun strikeCommands() =
                 infract(it.copy(args=newArgs))
 
                 StrikeRequests.map.remove(user.id)
-                user.sendPrivateMessage("Strike request was accepted. Thanks a bunch!" )
             }
         }
 
@@ -126,7 +125,6 @@ fun strikeCommands() =
                 if( !(strikeAgainst(user, it)) ) return@execute
 
                 StrikeRequests.map.remove(user.id)
-                user.sendPrivateMessage("Strike request was declined, better lucky next time :)")
             }
         }
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/StrikeCommands.kt
@@ -114,6 +114,7 @@ fun strikeCommands() =
                 infract(it.copy(args=newArgs))
 
                 StrikeRequests.map.remove(user.id)
+                it.respond("Strike request on ${user.asMention} was accepted.")
             }
         }
 
@@ -125,6 +126,7 @@ fun strikeCommands() =
                 if( !(strikeAgainst(user, it)) ) return@execute
 
                 StrikeRequests.map.remove(user.id)
+                it.respond("Strike request on ${user.asMention} was declined.")
             }
         }
 


### PR DESCRIPTION
Removed the debug messages which sent a direct message to the user as well as the infraction when a strike was accepted or declined