### PR TITLE
Voice channel mass mute / unmute commands

### DIFF
--- a/config/help.json
+++ b/config/help.json
@@ -793,6 +793,20 @@
       "description": "Eval code without a response",
       "structure": "{code}",
       "example": "event.respond('hi');"
+    },
+    {
+      "name": "mutevoicechannel",
+      "category": "moderation",
+      "description": "Mute all non-moderators in a voice channel.",
+      "structure": "{targetChannelId}",
+      "example": "134932042994309234"
+    },
+    {
+      "name": "unmutevoicechannel",
+      "category": "moderation",
+      "description": "Unmute all users in a voice channel.",
+      "structure": "{targetChannelId}",
+      "example": "134932042994309234"
     }
   ]
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/ModerationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/ModerationCommands.kt
@@ -15,9 +15,12 @@ import me.aberrantfox.hotbot.extensions.stdlib.retrieveIdToUser
 import me.aberrantfox.hotbot.extensions.stdlib.toRole
 import me.aberrantfox.hotbot.services.Configuration
 import me.aberrantfox.hotbot.utility.muteMember
+import me.aberrantfox.hotbot.utility.muteVoiceChannel
+import me.aberrantfox.hotbot.utility.unmuteVoiceChannel
 import net.dv8tion.jda.core.entities.Message
 import net.dv8tion.jda.core.entities.MessageChannel
 import net.dv8tion.jda.core.entities.User
+import net.dv8tion.jda.core.entities.VoiceChannel
 import java.awt.Color
 import java.io.File
 import java.text.SimpleDateFormat
@@ -294,6 +297,26 @@ fun moderationCommands() = commands {
                     user.sendPrivateMessage("Thank you for changing your avatar. You will not be banned.")
                 }
             }
+        }
+    }
+
+    command("mutevoicechannel") {
+        expect(ArgumentType.VoiceChannel)
+        execute {
+            val args = it.args
+            val voiceChannel = args[0] as VoiceChannel
+            muteVoiceChannel(it.guild, voiceChannel, it.author, it.config, it
+                    .manager)
+        }
+    }
+
+    command("unmutevoicechannel") {
+        expect(ArgumentType.VoiceChannel)
+        execute {
+            val args = it.args
+            val voiceChannel = args[0] as VoiceChannel
+            unmuteVoiceChannel(it.guild, voiceChannel, it.author, it.config, it
+                    .manager)
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/permissions/PermissionsManagement.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/permissions/PermissionsManagement.kt
@@ -79,4 +79,16 @@ data class PermissionManager(val map: HashMap<RoleID, HashSet<CommandName>> = Ha
 
         return lowerRoles.filter { map.containsKey(it) }
     }
+
+    fun getLowerRoleIds(roleID: RoleID?): List<String> {
+
+        if(roleID == null) return ArrayList()
+        val guild = jda.getGuildById(config.serverInformation.guildid)
+        val role = guild.roles.first { it.id == roleID }
+
+        return ArrayList(guild.roles
+                .filter { it.position < role.position }
+                .map { it.id }
+                .toList())
+    }
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/services/Configuration.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/services/Configuration.kt
@@ -39,7 +39,8 @@ data class ApiConfiguration(val cleverbotAPIKey: String = "insert-api-key",
 data class PermissionedActions(var sendInvite: String = "insert-role-id",
                                var sendURL: String = "insert-role-id",
                                var commandMention: String = "insert-role-id",
-                               val ignoreLogging: String = "insert-rold-id")
+                               val ignoreLogging: String = "insert-rold-id",
+                               var voiceChannelMuteThreshold: String = "insert-role-id")
 
 data class DatabaseCredentials(val username: String = "root",
                                val password: String = "",

--- a/src/main/kotlin/me/aberrantfox/hotbot/utility/JDAUtility.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/utility/JDAUtility.kt
@@ -3,18 +3,25 @@ package me.aberrantfox.hotbot.utility
 import me.aberrantfox.hotbot.database.deleteMutedMember
 import me.aberrantfox.hotbot.database.insertMutedMember
 import me.aberrantfox.hotbot.dsls.embed.embed
+import me.aberrantfox.hotbot.extensions.jda.getHighestRole
 import me.aberrantfox.hotbot.extensions.stdlib.convertToTimeString
+import me.aberrantfox.hotbot.permissions.PermissionManager
 import me.aberrantfox.hotbot.services.Configuration
 import net.dv8tion.jda.core.entities.Guild
 import net.dv8tion.jda.core.entities.User
+import net.dv8tion.jda.core.entities.VoiceChannel
 import java.awt.Color
 import java.util.*
 
 
-data class MuteRecord(val unmuteTime: Long, val reason: String, val moderator: String, val user: String, val guildId: String)
+data class MuteRecord(val unmuteTime: Long, val reason: String,
+                      val moderator: String, val user: String,
+                      val guildId: String)
 
-fun permMuteMember(guild: Guild, user: User, reason: String, config: Configuration, moderator: User) {
-    guild.controller.addRolesToMember(guild.getMemberById(user.id), guild.getRolesByName(config.security.mutedRole, true)).queue()
+fun permMuteMember(guild: Guild, user: User, reason: String,
+                   config: Configuration, moderator: User) {
+    guild.controller.addRolesToMember(guild.getMemberById(user.id),
+            guild.getRolesByName(config.security.mutedRole, true)).queue()
 
     user.openPrivateChannel().queue {
         val muteEmbed = buildMuteEmbed(user.asMention, "Indefinite", reason)
@@ -23,13 +30,16 @@ fun permMuteMember(guild: Guild, user: User, reason: String, config: Configurati
     }
 }
 
-fun muteMember(guild: Guild, user: User, time: Long, reason: String, config: Configuration, moderator: User) {
-    guild.controller.addRolesToMember(guild.getMemberById(user.id), guild.getRolesByName(config.security.mutedRole, true)).queue()
+fun muteMember(guild: Guild, user: User, time: Long, reason: String,
+               config: Configuration, moderator: User) {
+    guild.controller.addRolesToMember(guild.getMemberById(user.id),
+            guild.getRolesByName(config.security.mutedRole, true)).queue()
     val timeString = time.convertToTimeString()
 
     user.openPrivateChannel().queue {
         val timeToUnmute = futureTime(time)
-        val record = MuteRecord(timeToUnmute, reason, moderator.id, user.id, guild.id)
+        val record = MuteRecord(timeToUnmute, reason, moderator.id, user.id,
+                guild.id)
 
         val muteEmbed = buildMuteEmbed(user.asMention, timeString, reason)
         it.sendMessage(muteEmbed).queue()
@@ -39,32 +49,67 @@ fun muteMember(guild: Guild, user: User, time: Long, reason: String, config: Con
     }
 
     moderator.openPrivateChannel().queue {
-        it.sendMessage("User ${user.asMention} has been muted for $timeString, with reason:\n\n$reason").queue()
+        it.sendMessage(
+                "User ${user.asMention} has been muted for $timeString, with reason:\n\n$reason")
+                .queue()
     }
 }
 
-private fun buildMuteEmbed(userMention: String, timeString: String, reason: String) =
-    embed {
-        title("Mute")
-        description("$userMention, you have been muted.\nA muted user cannot speak, post in channels, or react to messages.")
+fun muteVoiceChannel(guild: Guild, voiceChannel: VoiceChannel,
+                      moderator: User, config: Configuration, manager: PermissionManager) {
 
-        field {
-            name = "Length"
-            value = timeString
-            inline = false
+    val mutedRoles = manager.getLowerRoleIds(config.permissionedActions
+            .voiceChannelMuteThreshold)
+
+    voiceChannel.members.forEach() {
+        if(mutedRoles.contains(it.getHighestRole()!!.id)) {
+            guild.controller.setMute(it, true).queue()
         }
-
-        field {
-            name = "__Reason__"
-            value = reason
-            inline = false
-        }
-
-
-        setColor(Color.RED)
     }
 
-fun scheduleUnmute(guild: Guild, user: User, config: Configuration, time: Long, muteRecord: MuteRecord) {
+    moderator.openPrivateChannel().queue {
+        it.sendMessage(
+                "All non-moderators in voice channel **${voiceChannel.name}** have been muted.").queue()
+    }
+}
+
+fun unmuteVoiceChannel(guild: Guild, voiceChannel: VoiceChannel,
+                     moderator: User, config: Configuration, manager: PermissionManager) {
+
+    voiceChannel.members.forEach() {
+            guild.controller.setMute(it, false).queue()
+    }
+
+    moderator.openPrivateChannel().queue {
+        it.sendMessage(
+                "All non-moderators in voice channel **${voiceChannel.name}** have been un-muted.").queue()
+    }
+}
+
+private fun buildMuteEmbed(userMention: String, timeString: String,
+                           reason: String) = embed {
+    title("Mute")
+    description(
+            "$userMention, you have been muted.\nA muted user cannot speak, post in channels, or react to messages.")
+
+    field {
+        name = "Length"
+        value = timeString
+        inline = false
+    }
+
+    field {
+        name = "__Reason__"
+        value = reason
+        inline = false
+    }
+
+
+    setColor(Color.RED)
+}
+
+fun scheduleUnmute(guild: Guild, user: User, config: Configuration, time: Long,
+                   muteRecord: MuteRecord) {
     if (time <= 0) {
         removeMuteRole(guild, user, config, muteRecord)
         return
@@ -77,7 +122,8 @@ fun scheduleUnmute(guild: Guild, user: User, config: Configuration, time: Long, 
     }, time)
 }
 
-fun removeMuteRole(guild: Guild, user: User, config: Configuration, record: MuteRecord) {
+fun removeMuteRole(guild: Guild, user: User, config: Configuration,
+                   record: MuteRecord) {
     if (user.mutualGuilds.isEmpty()) {
         deleteMutedMember(record)
         return
@@ -88,8 +134,13 @@ fun removeMuteRole(guild: Guild, user: User, config: Configuration, record: Mute
 }
 
 fun removeMuteRole(guild: Guild, user: User, config: Configuration) =
-    user.openPrivateChannel().queue {
-        it.sendMessage("${user.name} - you have been unmuted. Please respect our rules to prevent further infractions.").queue {
-            guild.controller.removeRolesFromMember(guild.getMemberById(user.id), guild.getRolesByName(config.security.mutedRole, true)).queue()
+        user.openPrivateChannel().queue {
+            it.sendMessage(
+                    "${user.name} - you have been unmuted. Please respect our rules to prevent further infractions.")
+                    .queue {
+                        guild.controller.removeRolesFromMember(
+                                guild.getMemberById(user.id),
+                                guild.getRolesByName(config.security.mutedRole,
+                                        true)).queue()
+                    }
         }
-    }


### PR DESCRIPTION
## Summary
Adds two commands which will allow a moderator to mass mute and unmute users in voice chat at their discretion. The mute action will only apply to roles which are **below** the one defined as the _"voiceChannelMuteThreshold"_ 

## Example Usage 



- _++mutevoicechannel (channel id)_
- _++unmutevoicechannel (channel id)_
