### PR TITLE
Added a channel delete listener to nuke resources of a channel

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
@@ -67,6 +67,7 @@ fun main(args: Array<String>) {
             InviteListener(config, logger, manager),
             VoiceChannelListener(logger),
             NewChannelListener(mutedRole),
+            ChannelDeleteListener(logger),
             DuplicateMessageListener(config, logger, tracker),
             RoleListener(config),
             PollListener(),

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/ChannelDeleteListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/ChannelDeleteListener.kt
@@ -1,0 +1,40 @@
+package me.aberrantfox.hotbot.listeners
+
+import me.aberrantfox.hotbot.database.ResourceSection
+import me.aberrantfox.hotbot.database.fetchChannelResources
+import me.aberrantfox.hotbot.database.removeAllChannelResources
+import me.aberrantfox.hotbot.dsls.embed.embed
+import me.aberrantfox.hotbot.logging.BotLogger
+import net.dv8tion.jda.core.entities.MessageChannel
+import net.dv8tion.jda.core.events.channel.text.TextChannelDeleteEvent
+import net.dv8tion.jda.core.hooks.ListenerAdapter
+import java.awt.Color
+
+class ChannelDeleteListener(val log: BotLogger) : ListenerAdapter() {
+    override fun onTextChannelDelete(event: TextChannelDeleteEvent) {
+        val resources = fetchChannelResources(event.channel.id, true)
+        if(resources.isEmpty()){
+            return
+        }
+        removeAllChannelResources(event.channel.id)
+        log.warning(buildDeleteResourcesEmbed(event.channel, resources))
+    }
+}
+private fun buildDeleteResourcesEmbed(channel: MessageChannel, resources: Map<String, ResourceSection>) =
+        embed {
+            setColor(Color.RED)
+            title("Deleted ${channel.name}'s resources")
+            description("Deleted channel resources:")
+
+            resources.forEach { _, rs ->
+                val sb = StringBuilder()
+
+                rs.items.forEach { info -> sb.append("$info\n") }
+
+                field {
+                    name = rs.section
+                    value = sb.toString()
+                    inline = false
+                }
+            }
+        }


### PR DESCRIPTION
As per the spec in #56 the resources in a channel are deleted when the channel is deleted

An embed is logged in the `warning` channel with the resources that the channel had