### PR TITLE
Added XKCD Commands.

### DIFF
--- a/config/help.json
+++ b/config/help.json
@@ -829,6 +829,27 @@
       "description": "Reroll an ended giveaway to get a new winner",
       "structure": "{messageID}",
       "example": "429853770063806466"
+    },
+    {
+      "name": "xkcd",
+      "category": "fun",
+      "description": "Returns the XKCD comic number specified, or a random comic if you don't supply a number.",
+      "structure": "{comicNumber}",
+      "example": "371"
+    },
+    {
+      "name": "xkcd-search",
+      "category": "fun",
+      "description": "Returns a XKCD comic that most closely matches your query.",
+      "structure": "{searchQuery}",
+      "example": "Exploits of a mom"
+    },
+    {
+      "name": "xkcd-latest",
+      "category": "fun",
+      "description": "Grabs the latest XKCD comic.",
+      "structure": "",
+      "example": ""
     }
   ]
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/XKCDCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/XKCDCommands.kt
@@ -1,0 +1,55 @@
+package me.aberrantfox.hotbot.commandframework.commands.utility
+
+import khttp.get
+import me.aberrantfox.hotbot.commandframework.parsing.ArgumentType
+import me.aberrantfox.hotbot.dsls.command.CommandSet
+import me.aberrantfox.hotbot.dsls.command.arg
+import me.aberrantfox.hotbot.dsls.command.commands
+import me.aberrantfox.hotbot.utility.randomInt
+import java.net.URLEncoder
+
+@CommandSet fun xkcdCommands() = commands {
+    command("xkcd") {
+        expect(arg(ArgumentType.Integer, true, -1))
+        execute {
+            val target = it.args.component1() as Int
+            val link = if (target == -1) {
+                produceURL(randomInt(1, getAmount()))
+            } else {
+                if (target <= getAmount() && target > 0) {
+                    produceURL(target)
+                } else {
+                    "Please enter a valid comic number between 1 and ${getAmount()}"
+                }
+            }
+            it.respond(link)
+        }
+    }
+
+    command("xkcd-latest") {
+        execute {
+            it.respond("https://xkcd.com/" + getAmount())
+        }
+    }
+
+    command("xkcd-search") {
+        expect(ArgumentType.Sentence)
+        execute {
+            val what = it.args.component1() as String
+            it.respond(produceURL(search(what)))
+        }
+    }
+}
+
+private fun search(what: String): Int {
+    val comicNumberParseRegex = "(?:\\S+\\s+){2}(\\S+)".toRegex()
+    return comicNumberParseRegex.find(
+            get("https://relevantxkcd.appspot.com/process?action=xkcd&query=" + URLEncoder.encode(
+                    what, "UTF-8")).text)!!.groups[1]?.value!!.toInt()
+}
+
+private fun getAmount() =
+        get("https://xkcd.com/info.0.json").jsonObject.getInt("num")
+
+private fun produceURL(comicNumber: Int) =
+        "http://xkcd.com/$comicNumber/"


### PR DESCRIPTION
## Summary

Adds the following commands for retrieving and searching XKCD comics: 

- xkcd (comic number) 
Returns a random comic if no comic number is supplied.  

- xkcd-search (search terms)
Returns the comic most relevant to your search query.

- xkcd-latest
Returns the latest comic. 

Closes #116 