### PR TITLE
Switched notes and infraction in history embed to same format

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/StrikeCommands.kt
@@ -309,7 +309,7 @@ private fun buildHistoryEmbed(target: User, includeModerator: Boolean, records: 
 
             records.forEach { record ->
                 field {
-                    name = "ID :: ${record.id} :: Weight :: ${record.strikes}"
+                    name = "ID :: __${record.id}__ :: Weight :: __${record.strikes}__"
                     value = "This infraction is **${expired(record.isExpired)}**."
                     inline = false
 
@@ -350,7 +350,7 @@ private fun buildHistoryEmbed(target: User, includeModerator: Boolean, records: 
             notes.forEach { note ->
                 field {
                     name = "ID :: __${note.id}__ :: Staff :: __${note.moderator.retrieveIdToName(it.jda)}__"
-                    value = "Noted on **${note.dateTime.toString(DateTimeFormat.forPattern("dd/MM/yyyy"))}**"
+                    value = "Noted by **${note.moderator.retrieveIdToName(it.jda)}** on **${note.dateTime.toString(DateTimeFormat.forPattern("dd/MM/yyyy"))}**"
                     inline = false
                 }
 


### PR DESCRIPTION
As per #126 
The old embed looked as such
![discord_2018-05-07_11-58-58](https://user-images.githubusercontent.com/34754130/39698756-11953e28-51ee-11e8-9d55-6ef789580dd1.png)
and the new embed
![discord_2018-05-07_11-59-29](https://user-images.githubusercontent.com/34754130/39698769-207ef244-51ee-11e8-8382-bfdb5aed5c12.png)

The issued by moderator is in the same format, the ID is underlined and the weight is underlined