### PR TITLE
duplicate message listener not displays tag

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/DuplicateMessageListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/DuplicateMessageListener.kt
@@ -61,7 +61,7 @@ class DuplicateMessageListener (val config: Configuration, val log: BotLogger, v
 
         tracker.list(id)?.forEach { it.message.delete().queue() }
 
-        log.warning("${event.author.fullName()} was muted for $reason")
+        log.warning("${event.author.asMention} (${event.author.fullName()}) was muted for $reason")
         tracker.removeUser(id)
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/DuplicateMessageListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/antispam/DuplicateMessageListener.kt
@@ -61,7 +61,7 @@ class DuplicateMessageListener (val config: Configuration, val log: BotLogger, v
 
         tracker.list(id)?.forEach { it.message.delete().queue() }
 
-        log.warning("${event.author.asMention} (${event.author.fullName()}) was muted for $reason")
+        log.warning("${event.author.descriptor()} was muted for $reason")
         tracker.removeUser(id)
     }
 }


### PR DESCRIPTION
As per #123 the muted message listener now displays a mentionable user as well as their user name.
`@moe (moe#9999) was muted for Automatic mute for repeat-spam detection due to security level Normal`