### PR TITLE
Added utility command `uploadtext` to upload to hastebin.

### DIFF
--- a/config/help.json
+++ b/config/help.json
@@ -892,6 +892,13 @@
       "description": "Grabs the latest XKCD comic.",
       "structure": "",
       "example": ""
+    },
+    {
+      "name": "uploadtext",
+      "category": "utility",
+      "description": "Uploads the given block of text/code to hastebin and removes the invocation",
+      "structure": "{text}",
+      "example": "print('Hello, World!')"
     }
   ]
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/FunCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/FunCommands.kt
@@ -30,7 +30,7 @@ fun funCommands() =
 
         command("flip") {
             execute {
-                val message = if (Random().nextBoolean()) "Heads" else "tails"
+                val message = if (Random().nextBoolean()) "Heads" else "Tails"
                 it.respond(message)
             }
         }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/UtilityCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/UtilityCommands.kt
@@ -14,6 +14,7 @@ import net.dv8tion.jda.core.entities.TextChannel
 import net.dv8tion.jda.core.entities.User
 import java.awt.Color
 import java.util.*
+import khttp.post
 
 data class Properties(val version: String, val author: String)
 
@@ -133,6 +134,18 @@ fun utilCommands() = commands {
         execute {
             val target = it.args.component1() as User
             it.respond("${target.fullName()}'s account was made on ${target.creationTime}")
+        }
+    }
+
+    command("uploadtext") {
+        expect(ArgumentType.Sentence)
+        execute {
+            it.message.delete().queue()
+
+            val text = it.args.component1() as String
+            val response = post("https://hastebin.com/documents", data = text).jsonObject
+
+            it.respond("${it.author.fullName()}'s paste: https://hastebin.com/" + response.getString("key"))
         }
     }
 }


### PR DESCRIPTION
Uploads the given block of text/code to hastebin and removes the invocation.

**Rationale:**
Useful in the obvious use cases of uploading blocks of code and it could double as "spoiler" tags to be used in the Competition and off topic channels.
