### PR TITLE
Save ignores and reminders in the DB and logging changes.

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
@@ -5,6 +5,7 @@ import me.aberrantfox.hotbot.commandframework.commands.development.EngineContain
 import me.aberrantfox.hotbot.commandframework.commands.development.EngineContainer.setupScriptEngine
 import me.aberrantfox.hotbot.commandframework.commands.utility.macros
 import me.aberrantfox.hotbot.database.getAllMutedMembers
+import me.aberrantfox.hotbot.database.forEachIgnoredID
 import me.aberrantfox.hotbot.database.setupDatabaseSchema
 import me.aberrantfox.hotbot.dsls.command.produceContainer
 import me.aberrantfox.hotbot.extensions.jda.hasRole
@@ -56,6 +57,8 @@ fun main(args: Array<String>) {
     val tracker = MessageTracker(1)
     val manager = PermissionManager(jda, container, config)
     val messageService = MService()
+
+    forEachIgnoredID { config.security.ignoredIDs.add(it) }
 
     container.newLogger(logger)
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/MainApp.kt
@@ -4,8 +4,10 @@ import me.aberrantfox.hotbot.commandframework.CommandExecutor
 import me.aberrantfox.hotbot.commandframework.commands.development.EngineContainer
 import me.aberrantfox.hotbot.commandframework.commands.development.EngineContainer.setupScriptEngine
 import me.aberrantfox.hotbot.commandframework.commands.utility.macros
+import me.aberrantfox.hotbot.commandframework.commands.utility.scheduleReminder
 import me.aberrantfox.hotbot.database.getAllMutedMembers
 import me.aberrantfox.hotbot.database.forEachIgnoredID
+import me.aberrantfox.hotbot.database.forEachReminder
 import me.aberrantfox.hotbot.database.setupDatabaseSchema
 import me.aberrantfox.hotbot.dsls.command.produceContainer
 import me.aberrantfox.hotbot.extensions.jda.hasRole
@@ -14,6 +16,7 @@ import me.aberrantfox.hotbot.listeners.antispam.DuplicateMessageListener
 import me.aberrantfox.hotbot.listeners.antispam.InviteListener
 import me.aberrantfox.hotbot.listeners.antispam.NewJoinListener
 import me.aberrantfox.hotbot.listeners.antispam.TooManyMentionsListener
+import me.aberrantfox.hotbot.logging.BotLogger
 import me.aberrantfox.hotbot.logging.convertChannels
 import me.aberrantfox.hotbot.permissions.PermissionManager
 import me.aberrantfox.hotbot.services.*
@@ -85,6 +88,7 @@ fun main(args: Array<String>) {
     }
 
     handleLTSMutes(config, jda)
+    loadReminders(jda, logger)
     EngineContainer.engine = setupScriptEngine(jda, container, config)
     logger.info("Fully setup, now ready for use.")
 }
@@ -136,5 +140,14 @@ private fun handleLTSMutes(config: Configuration, jda: JDA) {
         if(user != null) {
             scheduleUnmute(guild, user.user, config, difference, it)
         }
+    }
+}
+
+private fun loadReminders(jda: JDA, log: BotLogger) {
+    forEachReminder {
+        val difference = timeToDifference(it.remindTime)
+        val user = jda.getUserById(it.member)
+
+        scheduleReminder(user, it.message, difference, log)
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/ModerationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/ModerationCommands.kt
@@ -75,9 +75,11 @@ fun moderationCommands() = commands {
 
             if (config.security.ignoredIDs.contains(target)) {
                 config.security.ignoredIDs.remove(target)
+                deleteIgnoredID(target)
                 it.respond("Unignored $target")
             } else {
                 config.security.ignoredIDs.add(target)
+                insertIgnoredID(target)
                 it.respond("$target? Who? What? Don't know what that is. ;)")
             }
         }

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/SchedulerCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/SchedulerCommands.kt
@@ -1,11 +1,16 @@
 package me.aberrantfox.hotbot.commandframework.commands.utility
 
 import me.aberrantfox.hotbot.commandframework.parsing.ArgumentType
+import me.aberrantfox.hotbot.database.deleteReminder
+import me.aberrantfox.hotbot.database.insertReminder
 import me.aberrantfox.hotbot.dsls.command.CommandSet
 import me.aberrantfox.hotbot.dsls.command.commands
 import me.aberrantfox.hotbot.extensions.jda.fullName
 import me.aberrantfox.hotbot.extensions.jda.sendPrivateMessage
 import me.aberrantfox.hotbot.extensions.stdlib.convertToTimeString
+import me.aberrantfox.hotbot.logging.BotLogger
+import me.aberrantfox.hotbot.utility.futureTime
+import net.dv8tion.jda.core.entities.User
 import java.util.*
 import kotlin.concurrent.schedule
 import kotlin.math.roundToLong
@@ -20,11 +25,24 @@ fun schedulerCommands() = commands {
 
             it.respond("Got it, I'll remind you about that in ${timeMilliSecs.convertToTimeString()}")
 
-            Timer().schedule(timeMilliSecs) {
-                info("${it.author.fullName()} reminded themselves about: $title")
-                it.author.sendPrivateMessage("Hi, you asked me to remind you about: $title")
-            }
+            insertReminder(it.author.id, title as String, futureTime(timeMilliSecs))
+            scheduleReminder(it.author, title, timeMilliSecs, log)
         }
     }
+}
+
+fun scheduleReminder(user: User, message: String, timeMilli: Long, log: BotLogger) {
+    fun remindTask () {
+        deleteReminder(user.id, message)
+        log.info("${user.fullName()} reminded themselves about: $message")
+        user.sendPrivateMessage("Hi, you asked me to remind you about: $message")
+    }
+
+    if (timeMilli <= 0) {
+        remindTask()
+        return
+    }
+
+    Timer().schedule(timeMilli) { remindTask() }
 }
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/IgnoreTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/IgnoreTransactions.kt
@@ -3,8 +3,6 @@ package me.aberrantfox.hotbot.database
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.transaction
 
-data class IgnoreRecord(val id: String)
-
 fun forEachIgnoredID(action: (String) -> Unit) =
         transaction {
             IgnoredIDs.selectAll()

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/IgnoreTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/IgnoreTransactions.kt
@@ -1,0 +1,27 @@
+package me.aberrantfox.hotbot.database
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+
+data class IgnoreRecord(val id: String)
+
+fun forEachIgnoredID(action: (String) -> Unit) =
+        transaction {
+            IgnoredIDs.selectAll()
+                      .map { it[IgnoredIDs.id] }
+                      .forEach({ action.invoke(it) })
+        }
+
+fun insertIgnoredID(id: String) =
+        transaction {
+            IgnoredIDs.insert {
+                it[IgnoredIDs.id] = id
+            }
+        }
+
+fun deleteIgnoredID(id: String) =
+        transaction {
+            IgnoredIDs.deleteWhere {
+                Op.build { IgnoredIDs.id eq id }
+            }
+        }

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/ReminderTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/ReminderTransactions.kt
@@ -1,0 +1,37 @@
+package me.aberrantfox.hotbot.database
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+
+data class ReminderRecord(val id: Int,
+                          val member: String,
+                          val message: String,
+                          val remindTime: Long)
+
+fun forEachReminder(action: (ReminderRecord) -> Unit) =
+        transaction {
+            Reminder.selectAll()
+                      .map { ReminderRecord(
+                              it[Reminder.id],
+                              it[Reminder.member],
+                              it[Reminder.message],
+                              it[Reminder.remindTime])}
+                      .forEach({ action.invoke(it) })
+        }
+
+fun insertReminder(member: String, message: String, remindTime: Long) =
+        transaction {
+            Reminder.insert {
+                it[Reminder.member] = member
+                it[Reminder.message] = message
+                it[Reminder.remindTime] = remindTime
+            }
+        }
+
+fun deleteReminder(member: String, message: String) =
+        transaction {
+            Reminder.deleteWhere {
+                Op.build { (Reminder.member eq member) and (Reminder.message eq message) }
+            }
+        }
+

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/SetupOperations.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/SetupOperations.kt
@@ -28,7 +28,8 @@ fun setupDatabaseSchema(config: Configuration) {
     )
 
     transaction {
-        SchemaUtils.create(Strikes, HistoryCount, Suggestions, BanRecords, CommandPermissions, ChannelResources, Notes, MutedMember)
+        SchemaUtils.create(Strikes, HistoryCount, Suggestions, BanRecords, CommandPermissions,
+                ChannelResources, Notes, MutedMember, IgnoredIDs)
         logger.addLogger(StdOutSqlLogger)
     }
 }
@@ -90,4 +91,8 @@ object MutedMember : Table() {
     val reason = text("reason")
     val moderator = varchar("moderator", 18)
     val guildId = varchar("guildId", 18)
+}
+
+object IgnoredIDs : Table() {
+    val id = varchar("id", 18).primaryKey()
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/SetupOperations.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/SetupOperations.kt
@@ -29,7 +29,7 @@ fun setupDatabaseSchema(config: Configuration) {
 
     transaction {
         SchemaUtils.create(Strikes, HistoryCount, Suggestions, BanRecords, CommandPermissions,
-                ChannelResources, Notes, MutedMember, IgnoredIDs)
+                ChannelResources, Notes, MutedMember, IgnoredIDs, Reminder)
         logger.addLogger(StdOutSqlLogger)
     }
 }
@@ -95,4 +95,11 @@ object MutedMember : Table() {
 
 object IgnoredIDs : Table() {
     val id = varchar("id", 18).primaryKey()
+}
+
+object Reminder : Table() {
+    val id = integer("id").autoIncrement().primaryKey()
+    val member = varchar("member", 18)
+    val message = text("message")
+    val remindTime = long("remindTime")
 }

--- a/src/main/kotlin/me/aberrantfox/hotbot/listeners/MemberListener.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/listeners/MemberListener.kt
@@ -1,6 +1,7 @@
 package me.aberrantfox.hotbot.listeners
 
 import me.aberrantfox.hotbot.extensions.jda.fullName
+import me.aberrantfox.hotbot.extensions.stdlib.formatJdaDate
 import me.aberrantfox.hotbot.extensions.stdlib.randomListItem
 import me.aberrantfox.hotbot.logging.BotLogger
 import me.aberrantfox.hotbot.services.Configuration
@@ -21,6 +22,7 @@ class MemberListener(val configuration: Configuration, val logger: BotLogger, va
         val response = mService.messages.onJoin.randomListItem().replace("%name%", "${event.user.asMention}(${event.user.fullName()})")
         val userImage = event.user.effectiveAvatarUrl
 
+        logger.info("${event.user.fullName()} :: ${event.user.asMention} created on ${event.user.creationTime.toString().formatJdaDate()} -- joined the server")
         target?.sendMessage(buildJoinMessage(response, userImage))?.queue { msg->
             msg.addReaction("\uD83D\uDC4B").queue {
                 WelcomeMessages.map.put(event.user.id, msg.id)
@@ -31,7 +33,7 @@ class MemberListener(val configuration: Configuration, val logger: BotLogger, va
         }
     }
 
-    override fun onGuildMemberLeave(e: GuildMemberLeaveEvent) = logger.info("${e.user.asMention} left the server")
+    override fun onGuildMemberLeave(e: GuildMemberLeaveEvent) = logger.info("${e.user.fullName()} :: ${e.user.asMention} left the server")
 
     private fun buildJoinMessage(response: String, image: String) =
         EmbedBuilder()

--- a/src/main/kotlin/me/aberrantfox/hotbot/services/Configuration.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/services/Configuration.kt
@@ -23,7 +23,7 @@ open class ServerInformation(val token: String = "insert-token",
                              open val guildid: String = "insert-guild-id",
                              val suggestionPoolLimit: Int = 20)
 
-data class Security(val ignoredIDs: MutableSet<String> = mutableSetOf(),
+data class Security(@Transient val ignoredIDs: MutableSet<String> = mutableSetOf(),
                     var lockDownMode: Boolean = false,
                     val infractionActionMap: HashMap<Int, InfractionAction> = HashMap(),
                     val mutedRole: String = "Muted",


### PR DESCRIPTION
Closes #49 and #96 

Log user joins with creation dates.
It's very common to run a history on new users, logging creation date
would help reduce doing it manually.
User leave messages now contain username instead of just a mention which
turn into just their IDs on the clients, which provides very little information.