### PR TITLE
Addition of editnote command, replaceNote function, and help documentation

### DIFF
--- a/config/help.json
+++ b/config/help.json
@@ -271,6 +271,13 @@
       "example": ""
     },
     {
+      "name": "editNote",
+      "category": "infractions",
+      "description": "Edits a note by ID (listed in history)",
+      "structure": "{noteId} {edited note}",
+      "example": "17 This is the edited note"
+    },
+    {
       "name": "ping",
       "category": "utility",
       "description": "Pong!",

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/ModerationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/ModerationCommands.kt
@@ -254,6 +254,17 @@ fun moderationCommands() = commands {
         }
     }
 
+    command("editnote") {
+        expect(ArgumentType.Integer, ArgumentType.Sentence)
+        execute {
+            //get user id that note is placed on, use that in insertNote part. If possible, try to replace note at ID with a different note, rather than a different ID.
+            val noteId = it.args.component1() as Int
+            val note = it.args.component2() as String
+            replaceNote(noteId, note, it.author.id)
+            it.respond("Note $noteId has been updated.")
+        }
+    }
+
     command("badpfp") {
         expect(ArgumentType.User)
         execute {

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/NotesTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/NotesTransactions.kt
@@ -30,9 +30,7 @@ fun replaceNote(id: Int, note: String, moderator: String) =
                 it[Notes.moderator] = moderator
                 it[Notes.note] = note
                 it[Notes.date] = DateTime.now()
-
             }
-
         }
 
 

--- a/src/main/kotlin/me/aberrantfox/hotbot/database/NotesTransactions.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/database/NotesTransactions.kt
@@ -1,9 +1,11 @@
 package me.aberrantfox.hotbot.database
 
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
 import org.joda.time.DateTime
 
 data class NoteRecord(val id: Int,
@@ -21,6 +23,18 @@ fun insertNote(member: String, moderator: String, note: String) =
                 it[Notes.date] = DateTime.now()
             }
         }
+
+fun replaceNote(id: Int, note: String, moderator: String) =
+        transaction {
+            Notes.update({Notes.id eq id}) {
+                it[Notes.moderator] = moderator
+                it[Notes.note] = note
+                it[Notes.date] = DateTime.now()
+
+            }
+
+        }
+
 
 fun getNotesByUser(userId: String) =
         transaction {


### PR DESCRIPTION
### editnote
++editNote is used to edit a note by id.
This is helpful for spelling errors, or when it seems that a note needs to be worded differently. Rather than deleting the note and adding it in again, this can make the process slightly faster.
### Example usage scenario:
_Note ID 531 reads: Fox is a bad person_

++editnote 531 Fox is a good person

_Note ID 531 now reads the corrected version: Fox is a good person_