### PR TITLE
Added optional choice arguments to flip

### DIFF
--- a/config/help.json
+++ b/config/help.json
@@ -56,9 +56,9 @@
     {
       "name": "flip",
       "category": "fun",
-      "description": "Flips a coin.",
-      "structure": "",
-      "example": ""
+      "description": "Flips a coin. Optionally, print one of the choices given.",
+      "structure": "[{choice} | {choice} ...]",
+      "example": "Get work done | Browse #meme-bin | Take a power nap"
     },
     {
       "name": "dog",

--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/FunCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/utility/FunCommands.kt
@@ -4,6 +4,7 @@ import com.github.ricksbrown.cowsay.Cowsay
 import khttp.get as kget
 import me.aberrantfox.hotbot.commandframework.parsing.ArgumentType
 import me.aberrantfox.hotbot.dsls.command.CommandSet
+import me.aberrantfox.hotbot.dsls.command.arg
 import me.aberrantfox.hotbot.dsls.command.commands
 import org.jsoup.Jsoup
 import java.io.File
@@ -29,9 +30,13 @@ fun funCommands() =
         }
 
         command("flip") {
+            expect(arg(ArgumentType.Splitter, true, listOf("Heads", "Tails")))
             execute {
-                val message = if (Random().nextBoolean()) "Heads" else "Tails"
-                it.respond(message)
+                val options = it.args[0] as List<String>
+                var choice = options[Random().nextInt(options.size)]
+                if (options.size == 1)
+                    choice += "\n... were you expecting something else ? :thinking: Did you forget the `|` separator ?"
+                it.respond(choice)
             }
         }
 


### PR DESCRIPTION
If arguments seperated by | are given to flip, it'll print one of those,
default is still Heads/Tails.