### PR TITLE
Change ++strikerequest to log in alert channel instead of info channel

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/StrikeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hotbot/commandframework/commands/administration/StrikeCommands.kt
@@ -65,7 +65,7 @@ fun strikeCommands() =
 
                 StrikeRequests.map.put(target.id, request)
                 it.respond("This has been logged and will be accepted or declined, thank you.")
-                info("${it.author.fullName()} has a new strike request. Use viewRequest ${target.asMention} to see it.")
+                alert("${it.author.fullName()} has a new strike request. Use ++viewRequest ${target.asMention} to see it.")
             }
         }
 


### PR DESCRIPTION
## Reasoning
Info is already cluttered with command invocations, so it can be hard to notice when there is a strike request. Moving strike requests to the alert channel would better guarantee a faster response (especially for those who will have notifications enabled for the channel as do I)